### PR TITLE
Add loan and credit card installment calculators

### DIFF
--- a/404.html
+++ b/404.html
@@ -29,6 +29,18 @@
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡申请</span>
                 </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - 💳 **官方链接** - 直接跳转到银行官方网站
 - 🔍 **分类展示** - 按银行类型分类显示
 - ✨ **交互动画** - 流畅的悬浮和点击效果
+- 🧮 **贷款与分期计算器** - 在线测算贷款月供与信用卡分期费用
 - 📱 **移动端优化** - 完美适配手机和平板
 
 ## 包含银行列表
@@ -63,11 +64,17 @@
 ## 文件结构
 
 ```
-银行卡申请/
-├── index.html      # 主页面文件
-├── style.css       # 样式文件
-├── script.js       # 交互脚本
-└── README.md       # 说明文档
+银行卡推荐网站/
+├── index.html                                 # 主页面
+├── global-banks.html                          # 全球银行
+├── credit-cards.html                          # 信用卡申请
+├── exchange-rates.html                        # 实时汇率
+├── loan-interest-calculator.html              # 贷款利率计算器
+├── credit-card-installment-calculator.html    # 信用卡分期计算器
+├── style.css                                  # 全站样式
+├── script.js                                  # 基础交互脚本
+├── calculators.js                             # 计算器功能脚本
+└── README.md                                  # 使用说明
 ```
 
 ## 技术特点

--- a/calculators.js
+++ b/calculators.js
@@ -1,0 +1,335 @@
+// 计算器功能脚本
+// 该文件在贷款利率和信用卡分期计算器页面中使用
+
+document.addEventListener('DOMContentLoaded', () => {
+    const currencyFormatter = new Intl.NumberFormat('zh-CN', {
+        style: 'currency',
+        currency: 'CNY',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+
+    const decimalFormatter = new Intl.NumberFormat('zh-CN', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+
+    const integerFormatter = new Intl.NumberFormat('zh-CN', {
+        maximumFractionDigits: 0
+    });
+
+    const sanitizeNumber = (value, fallback = 0) => (Number.isFinite(value) ? value : fallback);
+    const clampToZero = (value) => {
+        if (!Number.isFinite(value)) {
+            return 0;
+        }
+
+        return value < 0 ? 0 : value;
+    };
+
+    const formatCurrency = (value) => currencyFormatter.format(sanitizeNumber(value));
+    const formatPercent = (value) => `${decimalFormatter.format(sanitizeNumber(value))}%`;
+    const formatInteger = (value) => integerFormatter.format(sanitizeNumber(value));
+
+    const renderError = (container, message) => {
+        container.innerHTML = `
+            <div class="error-text">
+                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                <span>${message}</span>
+            </div>
+        `;
+    };
+
+    // 贷款利率计算器
+    const loanForm = document.getElementById('loan-calculator-form');
+    const loanResults = document.getElementById('loan-results');
+
+    if (loanForm && loanResults) {
+        const amountInput = document.getElementById('loan-amount');
+        const rateInput = document.getElementById('loan-rate');
+        const termInput = document.getElementById('loan-term');
+        const termUnitSelect = document.getElementById('loan-term-unit');
+
+        let hasCalculated = false;
+
+        const calculateLoan = () => {
+            const principal = parseFloat(amountInput.value);
+            const annualRate = parseFloat(rateInput.value);
+            const termValue = parseFloat(termInput.value);
+            const termUnit = termUnitSelect ? termUnitSelect.value : 'years';
+
+            if (!Number.isFinite(principal) || principal <= 0) {
+                renderError(loanResults, '请输入有效的贷款总额。');
+                return;
+            }
+
+            if (!Number.isFinite(annualRate) || annualRate < 0) {
+                renderError(loanResults, '请输入正确的年化利率。');
+                return;
+            }
+
+            if (!Number.isFinite(termValue) || termValue <= 0) {
+                renderError(loanResults, '请输入正确的贷款期限。');
+                return;
+            }
+
+            const totalMonthsRaw = termUnit === 'months' ? termValue : termValue * 12;
+            const totalMonths = Math.round(totalMonthsRaw);
+
+            if (!Number.isFinite(totalMonths) || totalMonths <= 0) {
+                renderError(loanResults, '贷款期限需要大于 0。');
+                return;
+            }
+
+            const monthlyRate = annualRate / 12 / 100;
+            const isZeroRate = Math.abs(monthlyRate) < 1e-8;
+
+            let monthlyPayment;
+
+            if (isZeroRate) {
+                monthlyPayment = principal / totalMonths;
+            } else {
+                const compoundFactor = Math.pow(1 + monthlyRate, totalMonths);
+                monthlyPayment = principal * monthlyRate * compoundFactor / (compoundFactor - 1);
+            }
+
+            const totalPayment = monthlyPayment * totalMonths;
+            const totalInterest = totalPayment - principal;
+            const interestRatio = totalPayment > 0 ? (totalInterest / totalPayment) * 100 : 0;
+
+            const monthsToDisplay = Math.min(totalMonths, 12);
+            const amortizationRows = [];
+            let remainingPrincipal = principal;
+
+            for (let month = 1; month <= monthsToDisplay; month += 1) {
+                const interestPayment = isZeroRate ? 0 : remainingPrincipal * monthlyRate;
+                let principalPayment = monthlyPayment - interestPayment;
+
+                if (principalPayment > remainingPrincipal) {
+                    principalPayment = remainingPrincipal;
+                }
+
+                remainingPrincipal = clampToZero(remainingPrincipal - principalPayment);
+
+                amortizationRows.push({
+                    month,
+                    payment: monthlyPayment,
+                    interest: interestPayment,
+                    principal: principalPayment,
+                    remaining: remainingPrincipal
+                });
+            }
+
+            const firstMonthInterest = amortizationRows.length
+                ? amortizationRows[0].interest
+                : monthlyPayment - (principal / totalMonths);
+
+            const termYears = Math.floor(totalMonths / 12);
+            const termMonthsRemainder = totalMonths % 12;
+            let termDescription = `${formatInteger(totalMonths)} 期`;
+
+            if (termYears > 0) {
+                termDescription += '（约 ';
+                termDescription += `${termYears} 年`;
+
+                if (termMonthsRemainder > 0) {
+                    termDescription += ` ${termMonthsRemainder} 个月`;
+                }
+
+                termDescription += '）';
+            }
+
+            const rowsHtml = amortizationRows.map((row) => `
+                <tr>
+                    <td>${row.month}</td>
+                    <td>${formatCurrency(row.payment)}</td>
+                    <td>${formatCurrency(row.interest)}</td>
+                    <td>${formatCurrency(row.principal)}</td>
+                    <td>${formatCurrency(row.remaining)}</td>
+                </tr>
+            `).join('');
+
+            loanResults.innerHTML = `
+                <div class="result-summary">
+                    <div class="result-item">
+                        <span class="result-label">预计每月还款</span>
+                        <span class="result-value">${formatCurrency(monthlyPayment)}</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="result-label">总计利息支出</span>
+                        <span class="result-value">${formatCurrency(totalInterest)}</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="result-label">累计还款总额</span>
+                        <span class="result-value">${formatCurrency(totalPayment)}</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="result-label">首月利息</span>
+                        <span class="result-value">${formatCurrency(firstMonthInterest)}</span>
+                    </div>
+                </div>
+                <div class="result-breakdown">
+                    <p class="result-note">共 ${termDescription}，利息支出约占总还款的 ${formatPercent(interestRatio)}。当前计算默认采用等额本息还款方式。</p>
+                    <h4>前 ${monthsToDisplay} 期还款计划预览</h4>
+                    <div class="result-table-wrapper">
+                        <table class="result-table">
+                            <thead>
+                                <tr>
+                                    <th>期数</th>
+                                    <th>每期应还</th>
+                                    <th>其中利息</th>
+                                    <th>其中本金</th>
+                                    <th>剩余本金</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                ${rowsHtml}
+                            </tbody>
+                        </table>
+                    </div>
+                    ${totalMonths > monthsToDisplay ? `<p class="result-note">剩余 ${formatInteger(totalMonths - monthsToDisplay)} 期将继续以相同月供偿还，利息占比逐月下降。</p>` : ''}
+                    <p class="result-note">提示：实际月供可能因银行四舍五入规则存在微小差异，请以银行出具的还款计划为准。</p>
+                </div>
+            `;
+        };
+
+        loanForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            hasCalculated = true;
+            calculateLoan();
+        });
+
+        loanForm.addEventListener('input', () => {
+            if (hasCalculated) {
+                calculateLoan();
+            }
+        });
+    }
+
+    // 信用卡分期计算器
+    const installmentForm = document.getElementById('installment-calculator-form');
+    const installmentResults = document.getElementById('installment-results');
+
+    if (installmentForm && installmentResults) {
+        const amountInput = document.getElementById('installment-amount');
+        const monthsInput = document.getElementById('installment-months');
+        const feeRateInput = document.getElementById('installment-fee-rate');
+
+        let hasCalculated = false;
+
+        const calculateInstallment = () => {
+            const amount = parseFloat(amountInput.value);
+            const months = parseInt(monthsInput.value, 10);
+            const feeRate = parseFloat(feeRateInput.value);
+
+            if (!Number.isFinite(amount) || amount <= 0) {
+                renderError(installmentResults, '请输入有效的分期总金额。');
+                return;
+            }
+
+            if (!Number.isFinite(months) || months <= 0) {
+                renderError(installmentResults, '请输入正确的分期期数。');
+                return;
+            }
+
+            if (!Number.isFinite(feeRate) || feeRate < 0) {
+                renderError(installmentResults, '请输入正确的手续费率。');
+                return;
+            }
+
+            const monthlyFeeRate = feeRate / 100;
+            const basePrincipal = amount / months;
+            const monthlyFee = amount * monthlyFeeRate;
+            const monthlyPayment = basePrincipal + monthlyFee;
+            const totalFee = monthlyFee * months;
+            const totalPayment = amount + totalFee;
+            const annualizedRate = months > 0 ? (totalFee / amount) / (months / 12) * 100 : 0;
+
+            const scheduleRows = [];
+            let accumulatedPrincipal = 0;
+
+            for (let period = 1; period <= months; period += 1) {
+                let principalPayment = basePrincipal;
+
+                if (period === months) {
+                    principalPayment = amount - accumulatedPrincipal;
+                }
+
+                accumulatedPrincipal += principalPayment;
+                const remainingPrincipal = clampToZero(amount - accumulatedPrincipal);
+                const payment = principalPayment + monthlyFee;
+
+                scheduleRows.push({
+                    period,
+                    payment,
+                    principal: principalPayment,
+                    fee: monthlyFee,
+                    remaining: remainingPrincipal
+                });
+            }
+
+            const rowsHtml = scheduleRows.map((row) => `
+                <tr>
+                    <td>${row.period}</td>
+                    <td>${formatCurrency(row.payment)}</td>
+                    <td>${formatCurrency(row.principal)}</td>
+                    <td>${formatCurrency(row.fee)}</td>
+                    <td>${formatCurrency(row.remaining)}</td>
+                </tr>
+            `).join('');
+
+            installmentResults.innerHTML = `
+                <div class="result-summary">
+                    <div class="result-item">
+                        <span class="result-label">每期应还金额</span>
+                        <span class="result-value">${formatCurrency(monthlyPayment)}</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="result-label">每期手续费</span>
+                        <span class="result-value">${formatCurrency(monthlyFee)}</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="result-label">累计手续费</span>
+                        <span class="result-value">${formatCurrency(totalFee)}</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="result-label">折算年化费率</span>
+                        <span class="result-value">${formatPercent(annualizedRate)}</span>
+                    </div>
+                </div>
+                <div class="result-breakdown">
+                    <p class="result-note">共 ${formatInteger(months)} 期分期，假设手续费按每期固定比例收取且不提前还清。</p>
+                    <div class="result-table-wrapper">
+                        <table class="result-table">
+                            <thead>
+                                <tr>
+                                    <th>期数</th>
+                                    <th>每期应还</th>
+                                    <th>其中本金</th>
+                                    <th>分期手续费</th>
+                                    <th>剩余本金</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                ${rowsHtml}
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="result-note">说明：部分银行可能一次性收取手续费，实际费率以发卡行公布信息为准。</p>
+                </div>
+            `;
+        };
+
+        installmentForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            hasCalculated = true;
+            calculateInstallment();
+        });
+
+        installmentForm.addEventListener('input', () => {
+            if (hasCalculated) {
+                calculateInstallment();
+            }
+        });
+    }
+});

--- a/credit-card-installment-calculator.html
+++ b/credit-card-installment-calculator.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <!-- Google AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8794607118520437">
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>信用卡分期计算器 - 手续费与每期还款在线测算</title>
+    <meta name="description" content="信用卡分期计算器支持自定义分期金额、期数与每期手续费率，快速计算每期应还、总手续费及年化成本，辅助您做出理性分期决策。">
+    <meta name="keywords" content="信用卡分期计算器,信用卡分期手续费,信用卡还款计划,信用卡分期月供,信用卡理财">
+    <link rel="canonical" href="https://yinhangka.online/credit-card-installment-calculator.html">
+
+    <link rel="stylesheet" href="style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link active">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+            </nav>
+            <h1 class="logo">
+                <i class="fas fa-calculator"></i>
+                信用卡分期计算器
+            </h1>
+            <p class="subtitle">清晰了解每期本金与手续费，合理规划信用卡分期</p>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item">
+                            <span itemprop="name">首页</span>
+                        </a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">信用卡分期计算器</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+
+            <section class="hero">
+                <h2 class="hero-title">信用卡分期费用一目了然</h2>
+                <p class="hero-description">
+                    输入分期金额、期数与每期手续费率，即可得知每期应还金额、累计手续费及折算年化费率，
+                    帮助您快速判断分期成本是否合理。
+                </p>
+            </section>
+
+            <section class="calculator-section">
+                <div class="calculator-grid">
+                    <div class="calculator-card">
+                        <h3 class="calculator-title">
+                            <i class="fas fa-clipboard-check" aria-hidden="true"></i>
+                            分期参数设置
+                        </h3>
+                        <form id="installment-calculator-form" class="calculator-form">
+                            <div class="form-group">
+                                <label for="installment-amount">分期总金额</label>
+                                <div class="input-wrapper with-prefix">
+                                    <span class="input-prefix">¥</span>
+                                    <input type="number" id="installment-amount" name="installment-amount" inputmode="decimal" min="0" step="100" value="10000" placeholder="例如 10000" aria-describedby="installment-amount-helper" required>
+                                </div>
+                                <p class="form-helper" id="installment-amount-helper">请输入计划分期的消费金额或账单金额，单位为人民币。</p>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="installment-months">分期期数</label>
+                                <div class="input-wrapper with-suffix">
+                                    <input type="number" id="installment-months" name="installment-months" inputmode="numeric" min="1" step="1" value="12" placeholder="例如 12" aria-describedby="installment-months-helper" required>
+                                    <span class="input-suffix">期</span>
+                                </div>
+                                <p class="form-helper" id="installment-months-helper">常见分期期数有 3、6、12、18 期，可根据个人需求自定义。</p>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="installment-fee-rate">每期手续费率</label>
+                                <div class="input-wrapper with-suffix">
+                                    <input type="number" id="installment-fee-rate" name="installment-fee-rate" inputmode="decimal" min="0" step="0.01" value="0.60" placeholder="例如 0.60" aria-describedby="installment-fee-rate-helper" required>
+                                    <span class="input-suffix">%</span>
+                                </div>
+                                <p class="form-helper" id="installment-fee-rate-helper">多数银行的每期手续费率在 0.5% - 0.8% 左右，例如填写 0.60 表示每期手续费率为 0.60%。</p>
+                            </div>
+
+                            <button type="submit" class="calculator-submit">
+                                <i class="fas fa-calculator" aria-hidden="true"></i>
+                                计算分期费用
+                            </button>
+                        </form>
+
+                        <div class="calculator-results" id="installment-results" role="region" aria-live="polite" aria-atomic="true">
+                            <p class="placeholder-text">输入分期金额、期数与手续费率后，将展示每期应还及累计手续费情况。</p>
+                        </div>
+                    </div>
+
+                    <aside class="calculator-side">
+                        <div class="info-card">
+                            <h3><i class="fas fa-lightbulb" aria-hidden="true"></i> 使用提示</h3>
+                            <ul>
+                                <li>计算默认手续费按月收取，若为一次性收取，可改用总手续费 ÷ 期数得到近似每期费率。</li>
+                                <li>若提前还清，请关注发卡行是否返还未收取的手续费。</li>
+                                <li>合理安排分期期数，避免因过长周期增加不必要的手续费支出。</li>
+                            </ul>
+                        </div>
+                        <div class="info-card info-card--accent">
+                            <h3><i class="fas fa-shield-alt" aria-hidden="true"></i> 风险提示</h3>
+                            <p>信用卡分期属于有成本的融资方式，建议在预算充足、利率合理时使用。若出现还款压力，可及时与银行沟通调整还款方案。</p>
+                        </div>
+                    </aside>
+                </div>
+            </section>
+
+            <section class="calculator-tips">
+                <h3 class="section-title">
+                    <i class="fas fa-chart-line" aria-hidden="true"></i>
+                    分期决策小贴士
+                </h3>
+                <div class="tips-grid">
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-ruler" aria-hidden="true"></i> 如何评估分期成本？</h3>
+                        <p>关注折算年化费率，与同期贷款或消费信贷利率对比，若年化成本明显偏高，可考虑其他融资方式或提前还款。</p>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-wallet" aria-hidden="true"></i> 分期是否影响额度？</h3>
+                        <p>大部分银行在分期后会占用额度，按期还款后额度逐步恢复，建议预留日常消费空间。</p>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-hand-holding-usd" aria-hidden="true"></i> 分期前的准备</h3>
+                        <ul>
+                            <li>确认账单金额、账单日与还款日，避免逾期。</li>
+                            <li>了解银行的提前结清政策及手续费退还规则。</li>
+                            <li>评估自身收入情况，确保分期后仍有充足现金流。</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>关于我们</h4>
+                    <p>提供实用的金融工具与资讯，帮助您掌握信用卡与银行产品信息。</p>
+                </div>
+                <div class="footer-section">
+                    <h4>快捷入口</h4>
+                    <ul>
+                        <li><a href="/index.html">国内银行</a></li>
+                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/exchange-rates.html">实时汇率</a></li>
+                        <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
+                        <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>联系我们</h4>
+                    <p>若您在使用过程中有任何问题，欢迎通过网站客服渠道向我们反馈。</p>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 银行卡推荐网站. 保留所有权利。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="calculators.js"></script>
+</body>
+</html>

--- a/credit-cards.html
+++ b/credit-cards.html
@@ -31,6 +31,14 @@
                     <i class="fas fa-exchange-alt"></i>
                     <span>实时汇率</span>
                 </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>

--- a/exchange-rates.html
+++ b/exchange-rates.html
@@ -31,6 +31,14 @@
                     <i class="fas fa-exchange-alt"></i>
                     <span>实时汇率</span>
                 </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-chart-line"></i>

--- a/faq.html
+++ b/faq.html
@@ -30,6 +30,18 @@
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡申请</span>
                 </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>

--- a/global-banks.html
+++ b/global-banks.html
@@ -31,6 +31,14 @@
                     <i class="fas fa-exchange-alt"></i>
                     <span>实时汇率</span>
                 </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-globe-americas"></i>

--- a/index.html
+++ b/index.html
@@ -141,6 +141,14 @@
                     <i class="fas fa-exchange-alt"></i>
                     <span>实时汇率</span>
                 </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>
@@ -1207,6 +1215,8 @@
                         <a href="/privacy.html">隐私政策</a>
                         <a href="/terms.html">服务条款</a>
                         <a href="/faq.html">常见问题</a>
+                        <a href="/loan-interest-calculator.html">贷款利率计算器</a>
+                        <a href="/credit-card-installment-calculator.html">信用卡分期计算器</a>
                         <a href="/sitemap.xml">网站地图</a>
                     </div>
                 </div>

--- a/loan-interest-calculator.html
+++ b/loan-interest-calculator.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <!-- Google AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8794607118520437">
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>贷款利率计算器 - 房贷车贷等额本息月供在线计算</title>
+    <meta name="description" content="贷款利率计算器支持等额本息方式，一键计算房贷、车贷等贷款的月供、总利息和还款计划，帮助您快速制定还款方案。">
+    <meta name="keywords" content="贷款利率计算器,房贷月供计算器,等额本息计算器,贷款利息,房贷计算,车贷计算">
+    <link rel="canonical" href="https://yinhangka.online/loan-interest-calculator.html">
+
+    <link rel="stylesheet" href="style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link active">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+            </nav>
+            <h1 class="logo">
+                <i class="fas fa-coins"></i>
+                贷款利率计算器
+            </h1>
+            <p class="subtitle">轻松计算房贷、车贷等多种贷款的月供与利息</p>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item">
+                            <span itemprop="name">首页</span>
+                        </a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">贷款利率计算器</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+
+            <section class="hero">
+                <h2 class="hero-title">等额本息月供即时测算</h2>
+                <p class="hero-description">
+                    输入贷款金额、年化利率与还款期限，即可获得详细的等额本息月供计算结果，
+                    包括每月还款金额、利息支出、剩余本金以及前12期的还款计划预览。
+                </p>
+            </section>
+
+            <section class="calculator-section">
+                <div class="calculator-grid">
+                    <div class="calculator-card">
+                        <h3 class="calculator-title">
+                            <i class="fas fa-sliders-h" aria-hidden="true"></i>
+                            贷款参数设置
+                        </h3>
+                        <form id="loan-calculator-form" class="calculator-form">
+                            <div class="form-group">
+                                <label for="loan-amount">贷款总额</label>
+                                <div class="input-wrapper with-prefix">
+                                    <span class="input-prefix">¥</span>
+                                    <input type="number" id="loan-amount" name="loan-amount" inputmode="decimal" min="0" step="1000" value="500000" placeholder="例如 500000" aria-describedby="loan-amount-helper" required>
+                                </div>
+                                <p class="form-helper" id="loan-amount-helper">请输入贷款本金，单位为人民币，例如房贷或车贷的总额度。</p>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="loan-rate">年化利率</label>
+                                <div class="input-wrapper with-suffix">
+                                    <input type="number" id="loan-rate" name="loan-rate" inputmode="decimal" min="0" step="0.01" value="4.30" placeholder="例如 4.30" aria-describedby="loan-rate-helper" required>
+                                    <span class="input-suffix">%</span>
+                                </div>
+                                <p class="form-helper" id="loan-rate-helper">填写贷款合同中的年化利率，如 4.30 表示年利率 4.30%。</p>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="loan-term">贷款期限</label>
+                                <div class="input-grid">
+                                    <div class="input-wrapper">
+                                        <input type="number" id="loan-term" name="loan-term" inputmode="decimal" min="1" step="0.5" value="30" placeholder="例如 30" aria-describedby="loan-term-helper" required>
+                                    </div>
+                                    <div class="input-wrapper">
+                                        <select id="loan-term-unit" name="loan-term-unit" aria-label="贷款期限单位">
+                                            <option value="years" selected>年</option>
+                                            <option value="months">月</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <p class="form-helper" id="loan-term-helper">支持以年或月为单位的期限输入，系统会自动换算总期数。</p>
+                            </div>
+
+                            <button type="submit" class="calculator-submit">
+                                <i class="fas fa-equals" aria-hidden="true"></i>
+                                计算月供
+                            </button>
+                        </form>
+
+                        <div class="calculator-results" id="loan-results" role="region" aria-live="polite" aria-atomic="true">
+                            <p class="placeholder-text">填写贷款金额、利率与期限后，即可查看详细的月供金额及利息明细。</p>
+                        </div>
+                    </div>
+
+                    <aside class="calculator-side">
+                        <div class="info-card">
+                            <h3><i class="fas fa-lightbulb" aria-hidden="true"></i> 使用技巧</h3>
+                            <ul>
+                                <li>适用于商业贷款、公积金贷款及车贷等等额本息还款方式。</li>
+                                <li>如遇调整利率，可重新输入最新利率以获取最新月供。</li>
+                                <li>贷款期限支持小数输入，例如 20.5 年将自动换算为 246 期。</li>
+                            </ul>
+                        </div>
+                        <div class="info-card info-card--accent">
+                            <h3><i class="fas fa-info-circle" aria-hidden="true"></i> 温馨提示</h3>
+                            <p>计算结果仅供参考，实际放款利率会受个人资质、银行政策和市场利率变动影响。请以银行最终出具的还款计划为准。</p>
+                        </div>
+                    </aside>
+                </div>
+            </section>
+
+            <section class="calculator-tips">
+                <h3 class="section-title">
+                    <i class="fas fa-compass" aria-hidden="true"></i>
+                    贷款规划建议
+                </h3>
+                <div class="tips-grid">
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-equals" aria-hidden="true"></i> 等额本息是什么？</h3>
+                        <p>等额本息是最常见的贷款还款方式，每月还款金额固定，前期利息占比高，随着还款推进，本金占比逐渐提升，利息支出逐月减少。</p>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-percentage" aria-hidden="true"></i> 计算结果包含哪些信息？</h3>
+                        <p>系统将展示预计月供、总利息、累计还款额以及前 12 期的利息与本金占比，帮助您直观了解还款结构。</p>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-tasks" aria-hidden="true"></i> 如何降低还款压力？</h3>
+                        <ul>
+                            <li>适度延长贷款期限可降低月供，但总利息会相应增加。</li>
+                            <li>提前部分还款可缩短期限或减少利息支出。</li>
+                            <li>关注 LPR 及银行优惠活动，择机申请更优利率。</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>关于我们</h4>
+                    <p>为您提供最全面的银行服务信息和实用工具，助您合理规划财务。</p>
+                </div>
+                <div class="footer-section">
+                    <h4>快捷入口</h4>
+                    <ul>
+                        <li><a href="/index.html">国内银行</a></li>
+                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/exchange-rates.html">实时汇率</a></li>
+                        <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
+                        <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>联系我们</h4>
+                    <p>如有任何问题或建议，欢迎随时通过网站提供的联系方式与我们取得联系。</p>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 银行卡推荐网站. 保留所有权利。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="calculators.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -36,6 +36,22 @@
         <priority>0.9</priority>
     </url>
 
+    <!-- 贷款利率计算器 -->
+    <url>
+        <loc>https://yinhangka.online/loan-interest-calculator.html</loc>
+        <lastmod>2024-01-15</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+
+    <!-- 信用卡分期计算器 -->
+    <url>
+        <loc>https://yinhangka.online/credit-card-installment-calculator.html</loc>
+        <lastmod>2024-01-15</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+
     <!-- 银行详情页面（动态生成） -->
     <url>
         <loc>https://yinhangka.online/banks/icbc.html</loc>

--- a/style.css
+++ b/style.css
@@ -46,7 +46,7 @@ body {
     padding: 8px;
     border: 1px solid rgba(255, 255, 255, 0.2);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-    max-width: 600px;
+    max-width: 900px;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 2rem;
@@ -928,6 +928,382 @@ body {
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
 }
 
+/* 计算器页面样式 */
+.calculator-section {
+    margin-bottom: 4rem;
+}
+
+.calculator-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 2rem;
+    align-items: start;
+}
+
+.calculator-card {
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(243, 244, 255, 0.95));
+    border-radius: 20px;
+    padding: 2.5rem;
+    box-shadow: 0 20px 45px rgba(31, 41, 55, 0.18);
+    border: 1px solid rgba(102, 126, 234, 0.2);
+    position: relative;
+    overflow: hidden;
+}
+
+.calculator-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.08));
+    opacity: 0;
+    transition: opacity 0.4s ease;
+}
+
+.calculator-card:hover::before {
+    opacity: 1;
+}
+
+.calculator-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.calculator-title {
+    font-size: 1.6rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    color: #2d3748;
+}
+
+.calculator-title i {
+    color: #667eea;
+}
+
+.calculator-form {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.form-group {
+    display: block;
+}
+
+.form-group label {
+    font-weight: 600;
+    color: #2d3748;
+    display: block;
+    margin-bottom: 0.6rem;
+}
+
+.input-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 1rem;
+}
+
+.input-wrapper {
+    position: relative;
+}
+
+.input-wrapper input,
+.input-wrapper select {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(102, 126, 234, 0.35);
+    background: rgba(255, 255, 255, 0.95);
+    font-size: 1rem;
+    color: #1a202c;
+    box-shadow: 0 6px 18px rgba(102, 126, 234, 0.08);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    appearance: none;
+}
+
+.input-wrapper select {
+    cursor: pointer;
+}
+
+.input-wrapper.with-prefix input {
+    padding-left: 2.8rem;
+}
+
+.input-wrapper.with-suffix input {
+    padding-right: 2.8rem;
+}
+
+.input-prefix,
+.input-suffix {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #667eea;
+    font-weight: 600;
+    pointer-events: none;
+    font-size: 0.95rem;
+}
+
+.input-prefix {
+    left: 16px;
+}
+
+.input-suffix {
+    right: 16px;
+}
+
+.calculator-form input:focus,
+.calculator-form select:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.15);
+    outline: none;
+}
+
+.form-helper {
+    margin-top: 0.4rem;
+    font-size: 0.9rem;
+    color: #4a5568;
+    line-height: 1.5;
+}
+
+.calculator-submit {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.95rem 2.4rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.calculator-submit i {
+    font-size: 1rem;
+}
+
+.calculator-submit:hover {
+    transform: translateY(-1px) scale(1.01);
+    box-shadow: 0 16px 32px rgba(102, 126, 234, 0.35);
+}
+
+.calculator-results {
+    margin-top: 2.2rem;
+    padding: 2rem;
+    border-radius: 18px;
+    background: rgba(102, 126, 234, 0.08);
+    border: 1px solid rgba(102, 126, 234, 0.2);
+    color: #1a202c;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.placeholder-text {
+    color: #4a5568;
+    font-size: 0.95rem;
+}
+
+.result-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.2rem;
+    margin-bottom: 1.8rem;
+}
+
+.result-item {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 16px;
+    padding: 1.2rem 1.5rem;
+    border: 1px solid rgba(102, 126, 234, 0.18);
+    box-shadow: 0 12px 26px rgba(102, 126, 234, 0.18);
+    text-align: center;
+}
+
+.result-label {
+    display: block;
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #667eea;
+    margin-bottom: 0.4rem;
+}
+
+.result-value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #2d3748;
+}
+
+.result-breakdown h4 {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+    color: #2d3748;
+}
+
+.result-table-wrapper {
+    overflow-x: auto;
+    border-radius: 14px;
+    border: 1px solid rgba(102, 126, 234, 0.2);
+    background: rgba(255, 255, 255, 0.95);
+}
+
+.result-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 520px;
+}
+
+.result-table thead {
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.18), rgba(118, 75, 162, 0.18));
+}
+
+.result-table th,
+.result-table td {
+    padding: 0.8rem 1rem;
+    text-align: center;
+    font-size: 0.95rem;
+    color: #2d3748;
+}
+
+.result-table tbody tr:nth-child(even) {
+    background: rgba(102, 126, 234, 0.08);
+}
+
+.result-table tbody tr:hover {
+    background: rgba(102, 126, 234, 0.16);
+}
+
+.result-note {
+    margin-top: 1.2rem;
+    font-size: 0.9rem;
+    color: #4a5568;
+    line-height: 1.6;
+}
+
+.error-text {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 1rem 1.2rem;
+    border-radius: 14px;
+    background: rgba(229, 62, 62, 0.12);
+    border: 1px solid rgba(229, 62, 62, 0.35);
+    color: #c53030;
+    font-weight: 600;
+}
+
+.error-text i {
+    font-size: 1.1rem;
+}
+
+.calculator-side {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.info-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 18px;
+    padding: 1.8rem;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
+    border: 1px solid rgba(102, 126, 234, 0.2);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.info-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 36px rgba(102, 126, 234, 0.28);
+}
+
+.info-card--accent {
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.95), rgba(118, 75, 162, 0.95));
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.info-card--outline {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px dashed rgba(102, 126, 234, 0.4);
+}
+
+.info-card h3 {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: #2d3748;
+}
+
+.info-card h3 i {
+    color: #667eea;
+}
+
+.info-card--accent h3,
+.info-card--accent p,
+.info-card--accent li {
+    color: rgba(255, 255, 255, 0.95);
+}
+
+.info-card--accent h3 i {
+    color: #ffd700;
+}
+
+.info-card p {
+    color: #4a5568;
+    line-height: 1.7;
+}
+
+.info-card ul {
+    margin-left: 1.1rem;
+    color: #4a5568;
+    line-height: 1.6;
+}
+
+.info-card ul li {
+    margin-bottom: 0.4rem;
+}
+
+.info-card--accent ul {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.tips-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+}
+
+.calculator-tips {
+    margin-top: 3rem;
+}
+
+.result-table-wrapper::-webkit-scrollbar {
+    height: 8px;
+}
+
+.result-table-wrapper::-webkit-scrollbar-thumb {
+    background: rgba(102, 126, 234, 0.4);
+    border-radius: 999px;
+}
+
+.result-table-wrapper::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.6);
+    border-radius: 999px;
+}
+
+@media (max-width: 1024px) {
+    .calculator-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .calculator-card {
+        padding: 2.2rem;
+    }
+}
+
 /* 页脚 */
 .footer {
     background: rgba(0, 0, 0, 0.8);
@@ -1061,7 +1437,39 @@ body {
     .contact-phone i {
         font-size: 0.7rem;
     }
-    
+
+    .calculator-grid {
+        gap: 1.5rem;
+    }
+
+    .calculator-card {
+        padding: 2rem;
+    }
+
+    .calculator-results {
+        padding: 1.75rem;
+    }
+
+    .result-summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .tips-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .input-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .info-card {
+        padding: 1.6rem;
+    }
+
+    .result-table {
+        min-width: 100%;
+    }
+
     .footer-content {
         grid-template-columns: 1fr;
         gap: 1.5rem;
@@ -1079,6 +1487,43 @@ body {
     .banks-grid {
         grid-template-columns: repeat(3, 1fr);
         gap: 1.2rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .calculator-card {
+        padding: 1.5rem;
+    }
+
+    .calculator-title {
+        font-size: 1.4rem;
+    }
+
+    .calculator-results {
+        padding: 1.5rem;
+    }
+
+    .result-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .result-value {
+        font-size: 1.25rem;
+    }
+
+    .calculator-submit {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .info-card {
+        padding: 1.4rem;
+    }
+
+    .result-table th,
+    .result-table td {
+        padding: 0.6rem 0.75rem;
+        font-size: 0.85rem;
     }
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,16 @@
-const CACHE_NAME = 'bank-recommendation-v1.0.0';
+const CACHE_NAME = 'bank-recommendation-v1.1.0';
 const urlsToCache = [
   '/',
   '/index.html',
   '/style.css',
   '/script.js',
+  '/calculators.js',
   '/manifest.json',
   '/global-banks.html',
   '/credit-cards.html',
+  '/exchange-rates.html',
+  '/loan-interest-calculator.html',
+  '/credit-card-installment-calculator.html',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css'
 ];
 


### PR DESCRIPTION
## Summary
- add a loan interest calculator page with detailed form inputs, guidance blocks and result output
- add a credit card installment calculator page plus shared JavaScript logic to render results and validation
- update shared styling, navigation links, sitemap, service worker cache and documentation for the new tools

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce88405d7883219add0cab81a0541d