### PR TITLE
Add bank card BIN lookup tool

### DIFF
--- a/404.html
+++ b/404.html
@@ -41,6 +41,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 🔍 **分类展示** - 按银行类型分类显示
 - ✨ **交互动画** - 流畅的悬浮和点击效果
 - 🧮 **贷款与分期计算器** - 在线测算贷款月供与信用卡分期费用
+- 🔎 **BIN 号查询工具** - 输入卡号前几位识别发卡行与卡种
 - 📱 **移动端优化** - 完美适配手机和平板
 
 ## 包含银行列表
@@ -71,9 +72,11 @@
 ├── exchange-rates.html                        # 实时汇率
 ├── loan-interest-calculator.html              # 贷款利率计算器
 ├── credit-card-installment-calculator.html    # 信用卡分期计算器
+├── card-bin-lookup.html                       # 银行卡 BIN 号查询工具
 ├── style.css                                  # 全站样式
 ├── script.js                                  # 基础交互脚本
 ├── calculators.js                             # 计算器功能脚本
+├── bin-lookup.js                              # BIN 号查询脚本
 └── README.md                                  # 使用说明
 ```
 

--- a/bin-lookup.js
+++ b/bin-lookup.js
@@ -1,0 +1,533 @@
+(function () {
+    'use strict';
+
+    const HISTORY_KEY = 'binLookupHistory';
+    const MAX_HISTORY = 8;
+
+    const CARD_TYPE_MAP = {
+        credit: '信用卡',
+        debit: '借记卡',
+        prepaid: '预付卡',
+        charge: '签账卡'
+    };
+
+    const CARD_SCHEME_MAP = {
+        visa: 'VISA',
+        mastercard: 'Mastercard',
+        unionpay: '银联 UnionPay',
+        amex: 'American Express',
+        diners: 'Diners Club',
+        discover: 'Discover',
+        jcb: 'JCB',
+        maestro: 'Maestro',
+        elo: 'Elo',
+        mir: 'MIR',
+        rupay: 'RuPay'
+    };
+
+    const SOURCE_LABEL_MAP = {
+        api: '在线接口',
+        fallback: '离线参考'
+    };
+
+    const FALLBACK_BIN_DATA = {
+        '621483': {
+            scheme: 'unionpay',
+            brand: '长城借记卡',
+            type: 'debit',
+            bank: {
+                name: '中国银行',
+                phone: '95566',
+                url: 'https://www.boc.cn/'
+            },
+            country: {
+                alpha2: 'CN',
+                name: '中国',
+                emoji: '🇨🇳'
+            },
+            number: {
+                length: 19,
+                luhn: true
+            },
+            prepaid: false
+        },
+        '622202': {
+            scheme: 'unionpay',
+            brand: '牡丹信用卡',
+            type: 'credit',
+            bank: {
+                name: '中国工商银行',
+                phone: '95588',
+                url: 'https://www.icbc.com.cn/'
+            },
+            country: {
+                alpha2: 'CN',
+                name: '中国',
+                emoji: '🇨🇳'
+            },
+            number: {
+                length: 16,
+                luhn: true
+            },
+            prepaid: false
+        },
+        '622848': {
+            scheme: 'unionpay',
+            brand: '金穗借记卡',
+            type: 'debit',
+            bank: {
+                name: '中国农业银行',
+                phone: '95599',
+                url: 'https://www.abchina.com/'
+            },
+            country: {
+                alpha2: 'CN',
+                name: '中国',
+                emoji: '🇨🇳'
+            },
+            number: {
+                length: 19,
+                luhn: true
+            },
+            prepaid: false
+        },
+        '622588': {
+            scheme: 'unionpay',
+            brand: '招商银行信用卡',
+            type: 'credit',
+            bank: {
+                name: '招商银行',
+                phone: '95555',
+                url: 'https://www.cmbchina.com/'
+            },
+            country: {
+                alpha2: 'CN',
+                name: '中国',
+                emoji: '🇨🇳'
+            },
+            number: {
+                length: 16,
+                luhn: true
+            },
+            prepaid: false
+        },
+        '356833': {
+            scheme: 'jcb',
+            brand: 'JCB 白金卡',
+            type: 'credit',
+            bank: {
+                name: '中国建设银行',
+                phone: '95533',
+                url: 'https://www.ccb.com/'
+            },
+            country: {
+                alpha2: 'CN',
+                name: '中国',
+                emoji: '🇨🇳'
+            },
+            number: {
+                length: 16,
+                luhn: true
+            },
+            prepaid: false
+        }
+    };
+
+    const sanitizeBin = (value) => (value || '').replace(/\D/g, '').slice(0, 8);
+
+    const escapeHTML = (value) => String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    const formatScheme = (scheme) => {
+        if (!scheme) {
+            return '未知卡组织';
+        }
+
+        const normalized = String(scheme).toLowerCase();
+        return CARD_SCHEME_MAP[normalized] || scheme.toString().toUpperCase();
+    };
+
+    const formatType = (type) => {
+        if (!type) {
+            return '未知卡种';
+        }
+
+        const normalized = String(type).toLowerCase();
+        return CARD_TYPE_MAP[normalized] || type;
+    };
+
+    const formatBoolean = (value, positiveText, negativeText) => {
+        if (value === true) {
+            return positiveText;
+        }
+
+        if (value === false) {
+            return negativeText;
+        }
+
+        return '未知';
+    };
+
+    const formatCountry = (country) => {
+        if (!country) {
+            return '暂无数据';
+        }
+
+        const parts = [];
+
+        if (country.emoji) {
+            parts.push(escapeHTML(country.emoji));
+        }
+
+        if (country.name) {
+            parts.push(escapeHTML(country.name));
+        }
+
+        if (country.alpha2) {
+            parts.push(`(${escapeHTML(String(country.alpha2).toUpperCase())})`);
+        }
+
+        return parts.join(' ');
+    };
+
+    const validateUrl = (value) => {
+        if (typeof value !== 'string' || value.trim() === '') {
+            return null;
+        }
+
+        try {
+            return new URL(value).toString();
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const loadHistory = () => {
+        try {
+            const raw = window.localStorage.getItem(HISTORY_KEY);
+            if (!raw) {
+                return [];
+            }
+
+            const parsed = JSON.parse(raw);
+            if (Array.isArray(parsed)) {
+                return parsed;
+            }
+        } catch (error) {
+            console.warn('无法读取 BIN 查询历史记录：', error);
+        }
+
+        return [];
+    };
+
+    const saveHistory = (records) => {
+        try {
+            window.localStorage.setItem(HISTORY_KEY, JSON.stringify(records));
+        } catch (error) {
+            console.warn('无法保存 BIN 查询历史记录：', error);
+        }
+    };
+
+    const clearHistory = () => {
+        try {
+            window.localStorage.removeItem(HISTORY_KEY);
+        } catch (error) {
+            console.warn('无法清除 BIN 查询历史记录：', error);
+        }
+    };
+
+    const getFallbackData = (bin) => {
+        const normalized = sanitizeBin(bin);
+        for (let length = Math.min(normalized.length, 8); length >= 6; length -= 1) {
+            const prefix = normalized.slice(0, length);
+            if (Object.prototype.hasOwnProperty.call(FALLBACK_BIN_DATA, prefix)) {
+                return {
+                    data: FALLBACK_BIN_DATA[prefix],
+                    matchedPrefix: prefix
+                };
+            }
+        }
+
+        return null;
+    };
+
+    const renderPlaceholderHistory = (historyContainer) => {
+        historyContainer.innerHTML = '<li class="bin-history-empty">暂无查询记录，输入 BIN 号即可开始。</li>';
+    };
+
+    const renderHistory = (historyContainer, historyRecords) => {
+        if (!historyRecords.length) {
+            renderPlaceholderHistory(historyContainer);
+            return;
+        }
+
+        const itemsHtml = historyRecords.map((record) => {
+            const bankName = record.bank ? escapeHTML(record.bank) : '未知发卡行';
+            const schemeLabel = record.scheme ? escapeHTML(record.scheme) : '未知卡组织';
+            const typeLabel = record.type ? escapeHTML(record.type) : '未知卡种';
+            const sourceLabel = SOURCE_LABEL_MAP[record.source] || '未知来源';
+
+            return `
+                <li>
+                    <button type="button" class="bin-history-item" data-bin="${record.bin}">
+                        <span class="bin-history-bin">${record.bin}</span>
+                        <span class="bin-history-bank">${bankName}</span>
+                        <span class="bin-history-meta">${schemeLabel} · ${typeLabel}</span>
+                        <span class="bin-history-source">数据源：${sourceLabel}</span>
+                    </button>
+                </li>
+            `;
+        }).join('');
+
+        historyContainer.innerHTML = itemsHtml;
+    };
+
+    const updateHistory = (bin, details, source, historyContainer) => {
+        const currentHistory = loadHistory();
+        const normalizedBin = sanitizeBin(bin);
+
+        const filtered = currentHistory.filter((item) => item.bin !== normalizedBin);
+        const newRecord = {
+            bin: normalizedBin,
+            bank: details.bankName,
+            scheme: details.schemeLabel,
+            type: details.cardType,
+            source,
+            timestamp: Date.now()
+        };
+
+        filtered.unshift(newRecord);
+
+        const limited = filtered.slice(0, MAX_HISTORY);
+        saveHistory(limited);
+        renderHistory(historyContainer, limited);
+    };
+
+    const renderError = (resultsContainer, message) => {
+        resultsContainer.innerHTML = `
+            <div class="error-text">
+                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                <span>${escapeHTML(message)}</span>
+            </div>
+        `;
+    };
+
+    const renderLoading = (resultsContainer, bin) => {
+        const label = bin ? `正在查询 BIN ${bin} 的信息...` : '正在查询 BIN 信息...';
+        resultsContainer.innerHTML = `
+            <p class="placeholder-text">
+                <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                ${escapeHTML(label)}
+            </p>
+        `;
+    };
+
+    const renderResult = (resultsContainer, bin, payload, sourceMeta) => {
+        const source = sourceMeta.source || 'api';
+        const data = payload || {};
+        const bank = data.bank || {};
+        const country = data.country || {};
+        const numberInfo = data.number || {};
+
+        const schemeLabel = formatScheme(data.scheme);
+        const cardType = formatType(data.type);
+        const brand = data.brand ? escapeHTML(data.brand) : '暂无数据';
+        const bankName = bank.name ? escapeHTML(bank.name) : '暂无数据';
+        const bankPhone = bank.phone ? escapeHTML(bank.phone) : '暂无数据';
+        const bankUrl = validateUrl(bank.url);
+        const bankCity = bank.city ? escapeHTML(bank.city) : '';
+        const countryLabel = formatCountry(country);
+        const prepaidLabel = formatBoolean(data.prepaid, '是', '否');
+        const lengthLabel = Number.isFinite(numberInfo.length) ? `${numberInfo.length} 位` : '未知';
+        const luhnLabel = formatBoolean(numberInfo.luhn, '支持', '不支持');
+        const sourceLabel = SOURCE_LABEL_MAP[source] || '未知来源';
+        const matchedPrefix = sourceMeta.matchedPrefix && sourceMeta.matchedPrefix !== bin
+            ? sourceMeta.matchedPrefix
+            : null;
+
+        const detailItems = [
+            {
+                label: '发卡行',
+                value: bankUrl
+                    ? `<a href="${escapeHTML(bankUrl)}" target="_blank" rel="noopener">${bankName}</a>${bankCity ? `（${bankCity}）` : ''}`
+                    : `${bankName}${bankCity ? `（${bankCity}）` : ''}`
+            },
+            {
+                label: '卡组织',
+                value: schemeLabel
+            },
+            {
+                label: '卡种类型',
+                value: cardType
+            },
+            {
+                label: '产品等级',
+                value: brand
+            },
+            {
+                label: '所属国家/地区',
+                value: countryLabel
+            },
+            {
+                label: '是否预付卡',
+                value: prepaidLabel
+            },
+            {
+                label: '卡号长度',
+                value: lengthLabel
+            },
+            {
+                label: 'Luhn 校验',
+                value: luhnLabel
+            },
+            {
+                label: '发卡行电话',
+                value: bankPhone
+            }
+        ];
+
+        const itemsHtml = detailItems.map((item) => `
+            <div class="bin-detail-item">
+                <span class="bin-detail-label">${escapeHTML(item.label)}</span>
+                <span class="bin-detail-value">${item.value || '暂无数据'}</span>
+            </div>
+        `).join('');
+
+        const noteText = source === 'fallback'
+            ? '当前结果来源于本地参考库，仅供快速核对。建议联系发卡银行或官方渠道确认最终信息。'
+            : '以上信息来源于公开 BIN 数据接口，仅供参考，实际信息请以发卡银行为准。';
+
+        const prefixNote = matchedPrefix
+            ? `<li>使用了本地 BIN 前缀 <span class="bin-highlight">${escapeHTML(matchedPrefix)}</span> 的参考数据。</li>`
+            : '';
+
+        resultsContainer.innerHTML = `
+            <div class="bin-results-summary">
+                <span class="bin-number">BIN ${escapeHTML(bin)}</span>
+                <span class="bin-results-badge"><i class="fas fa-network-wired" aria-hidden="true"></i>${schemeLabel}</span>
+                <span class="bin-results-badge"><i class="fas fa-id-card" aria-hidden="true"></i>${cardType}</span>
+                <span class="bin-detail-source"><i class="fas fa-database" aria-hidden="true"></i>数据来源：${sourceLabel}</span>
+            </div>
+            <div class="bin-details-grid">
+                ${itemsHtml}
+            </div>
+            <p class="bin-results-note">
+                ${noteText}
+                ${prefixNote ? `<ul class="bin-note-list">${prefixNote}</ul>` : ''}
+            </p>
+        `;
+
+        return {
+            bankName: bank.name || '未知发卡行',
+            schemeLabel,
+            cardType
+        };
+    };
+
+    const fetchBinInformation = async (bin) => {
+        const endpoint = `https://lookup.binlist.net/${bin}`;
+        const response = await fetch(endpoint, {
+            headers: {
+                Accept: 'application/json'
+            }
+        });
+
+        if (!response.ok) {
+            const error = new Error('请求 BIN 信息失败');
+            error.status = response.status;
+            throw error;
+        }
+
+        return response.json();
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const form = document.getElementById('bin-lookup-form');
+        const input = document.getElementById('card-bin');
+        const resultsContainer = document.getElementById('bin-results');
+        const historyContainer = document.getElementById('bin-history-list');
+        const clearButton = document.getElementById('clear-bin-history');
+
+        if (!form || !input || !resultsContainer || !historyContainer) {
+            return;
+        }
+
+        const initialHistory = loadHistory();
+        renderHistory(historyContainer, initialHistory);
+
+        input.addEventListener('input', (event) => {
+            const sanitized = sanitizeBin(event.target.value);
+            if (sanitized !== event.target.value) {
+                event.target.value = sanitized;
+            }
+        });
+
+        const handleLookup = async (bin) => {
+            const normalizedBin = sanitizeBin(bin);
+
+            if (normalizedBin.length < 6) {
+                input.setAttribute('aria-invalid', 'true');
+                renderError(resultsContainer, '请输入至少 6 位数字的 BIN 号。');
+                return;
+            }
+
+            input.setAttribute('aria-invalid', 'false');
+            renderLoading(resultsContainer, normalizedBin);
+
+            try {
+                const apiData = await fetchBinInformation(normalizedBin);
+                const details = renderResult(resultsContainer, normalizedBin, apiData, { source: 'api' });
+                updateHistory(normalizedBin, details, 'api', historyContainer);
+            } catch (error) {
+                console.warn('在线查询 BIN 信息失败，尝试使用本地数据。', error);
+                const fallback = getFallbackData(normalizedBin);
+
+                if (fallback) {
+                    const details = renderResult(resultsContainer, normalizedBin, fallback.data, {
+                        source: 'fallback',
+                        matchedPrefix: fallback.matchedPrefix
+                    });
+                    updateHistory(normalizedBin, details, 'fallback', historyContainer);
+                } else if (error.status === 404) {
+                    renderError(resultsContainer, '未查询到该 BIN 对应的信息，请核实输入是否正确。');
+                } else {
+                    renderError(resultsContainer, '查询失败，请检查网络连接或稍后再试。');
+                }
+            }
+        };
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const normalized = sanitizeBin(input.value);
+            input.value = normalized;
+            handleLookup(normalized);
+        });
+
+        historyContainer.addEventListener('click', (event) => {
+            const trigger = event.target.closest('.bin-history-item');
+            if (!trigger) {
+                return;
+            }
+
+            const { bin } = trigger.dataset;
+            if (!bin) {
+                return;
+            }
+
+            input.value = bin;
+            input.focus();
+            handleLookup(bin);
+        });
+
+        if (clearButton) {
+            clearButton.addEventListener('click', () => {
+                clearHistory();
+                renderPlaceholderHistory(historyContainer);
+            });
+        }
+    });
+})();

--- a/card-bin-lookup.html
+++ b/card-bin-lookup.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <!-- Google AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8794607118520437">
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>银行卡 BIN 号查询工具 - 快速识别发卡行与卡种信息</title>
+    <meta name="description" content="输入银行卡号前 6-8 位即可识别发卡行、卡组织、卡种类型以及支持的国家地区，助您核实银行卡信息。">
+    <meta name="keywords" content="银行卡BIN查询,银行卡归属查询,BIN号查询,发卡行识别,卡组织查询,银行卡工具">
+    <link rel="canonical" href="https://yinhangka.online/card-bin-lookup.html">
+
+    <link rel="stylesheet" href="style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+                <a href="card-bin-lookup.html" class="nav-link active">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
+            </nav>
+            <h1 class="logo">
+                <i class="fas fa-barcode"></i>
+                银行卡 BIN 号查询工具
+            </h1>
+            <p class="subtitle">核实发卡行与卡种信息，保障支付安全</p>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item">
+                            <span itemprop="name">首页</span>
+                        </a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">银行卡 BIN 号查询</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+
+            <section class="hero">
+                <h2 class="hero-title">输入 BIN 号，快速识别银行卡信息</h2>
+                <p class="hero-description">
+                    BIN（Bank Identification Number）是银行卡号的前 6-8 位，通过查询 BIN 号可以确认银行卡的发卡行、卡组织、卡种类型以及所属国家/地区，帮助您在支付前完成核验。
+                </p>
+            </section>
+
+            <section class="calculator-section">
+                <div class="calculator-grid">
+                    <div class="calculator-card">
+                        <h3 class="calculator-title">
+                            <i class="fas fa-search"></i>
+                            输入 BIN 号进行查询
+                        </h3>
+                        <form id="bin-lookup-form" class="calculator-form" novalidate>
+                            <div class="form-group">
+                                <label for="card-bin">银行卡 BIN 号</label>
+                                <div class="input-wrapper">
+                                    <input type="text" id="card-bin" name="card-bin" inputmode="numeric" pattern="[0-9]{6,8}" maxlength="8" autocomplete="off" placeholder="例如 621483" aria-describedby="card-bin-helper" required>
+                                </div>
+                                <p class="form-helper" id="card-bin-helper">请输入银行卡号前 <strong>6-8 位数字</strong>。BIN 号通常印刻在银行卡卡号的最前端，用于识别发卡行与卡组织。</p>
+                            </div>
+                            <button type="submit" class="calculator-submit">
+                                <i class="fas fa-search"></i>
+                                查询 BIN 信息
+                            </button>
+                        </form>
+
+                        <div class="calculator-results" id="bin-results" role="status" aria-live="polite" aria-atomic="true">
+                            <p class="placeholder-text">输入 BIN 号后即可查看发卡行、卡组织、卡种类型以及是否支持 Luhn 校验等详细资料。</p>
+                        </div>
+                    </div>
+
+                    <aside class="calculator-side">
+                        <div class="info-card">
+                            <h3><i class="fas fa-lightbulb"></i> 使用建议</h3>
+                            <ul>
+                                <li>优先输入完整的 6 位 BIN 号，部分银行的 BIN 会延伸到 8 位。</li>
+                                <li>如需确认跨境卡片，可留意卡组织及所属国家信息。</li>
+                                <li>查询结果可用于核实网购、绑定支付或识别未知来历的银行卡。</li>
+                            </ul>
+                        </div>
+                        <div class="info-card info-card--accent">
+                            <h3><i class="fas fa-shield-alt"></i> 隐私与安全提示</h3>
+                            <p>本工具仅需前 6-8 位 BIN 号即可完成查询，无需提交完整卡号。请勿在公共场合泄露完整的银行卡信息，保障个人资金安全。</p>
+                        </div>
+                    </aside>
+                </div>
+            </section>
+
+            <section class="bin-history-section">
+                <div class="bin-history-header">
+                    <h3 class="section-title">
+                        <i class="fas fa-clock-rotate-left"></i>
+                        查询记录
+                    </h3>
+                    <p>最近查询的 BIN 会保存在本设备中，方便您快速再次核实相关银行卡信息。点击记录即可重新加载详情。</p>
+                </div>
+                <ul class="bin-history-list" id="bin-history-list" aria-live="polite" aria-atomic="false">
+                    <li class="bin-history-empty">暂无查询记录，输入 BIN 号即可开始。</li>
+                </ul>
+                <div class="bin-history-actions">
+                    <button type="button" id="clear-bin-history">清空本地记录</button>
+                </div>
+            </section>
+
+            <section class="calculator-tips">
+                <h3 class="section-title">
+                    <i class="fas fa-circle-info"></i>
+                    BIN 号常见问题解答
+                </h3>
+                <div class="tips-grid">
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-question-circle"></i> BIN 号包含哪些信息？</h3>
+                        <p>BIN 号可用于识别发卡银行、卡组织（如银联、VISA、Mastercard 等）、卡片类型（借记卡、信用卡、预付卡）以及卡号长度是否符合 Luhn 校验等特征。</p>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-sitemap"></i> 为什么查询结果可能不完整？</h3>
+                        <p>部分新发行或地区性银行的 BIN 数据可能未完整收录。遇到缺失信息时，可联系发卡银行客服核实或尝试输入更长的 8 位 BIN。</p>
+                    </div>
+                    <div class="info-card info-card--accent">
+                        <h3><i class="fas fa-user-shield"></i> 如何安全使用查询结果？</h3>
+                        <ul>
+                            <li>确认收款方提供的银行卡信息是否与查询结果一致。</li>
+                            <li>核实陌生银行卡来源，避免卷入诈骗或洗钱风险。</li>
+                            <li>遇到疑似风险卡片时，及时联系发卡银行或支付平台客服。</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>关于我们</h4>
+                    <p>为您提供最全面的银行服务信息和实用工具，帮助您安全、高效地处理银行卡事务。</p>
+                </div>
+                <div class="footer-section">
+                    <h4>快捷入口</h4>
+                    <ul>
+                        <li><a href="/index.html">国内银行</a></li>
+                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/exchange-rates.html">实时汇率</a></li>
+                        <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
+                        <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>
+                        <li><a href="/card-bin-lookup.html">BIN 号查询工具</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>联系我们</h4>
+                    <p>如有任何问题或建议，欢迎随时通过网站提供的联系方式与我们取得联系。</p>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 银行卡推荐网站. 保留所有权利。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="bin-lookup.js"></script>
+</body>
+</html>

--- a/credit-card-installment-calculator.html
+++ b/credit-card-installment-calculator.html
@@ -43,6 +43,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-calculator"></i>
@@ -182,6 +186,7 @@
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>
+                        <li><a href="/card-bin-lookup.html">BIN 号查询工具</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">

--- a/credit-cards.html
+++ b/credit-cards.html
@@ -39,6 +39,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>

--- a/exchange-rates.html
+++ b/exchange-rates.html
@@ -39,6 +39,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-chart-line"></i>

--- a/faq.html
+++ b/faq.html
@@ -42,6 +42,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>

--- a/global-banks.html
+++ b/global-banks.html
@@ -39,6 +39,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-globe-americas"></i>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-credit-card"></i>
@@ -1217,6 +1221,7 @@
                         <a href="/faq.html">常见问题</a>
                         <a href="/loan-interest-calculator.html">贷款利率计算器</a>
                         <a href="/credit-card-installment-calculator.html">信用卡分期计算器</a>
+                        <a href="/card-bin-lookup.html">BIN 号查询工具</a>
                         <a href="/sitemap.xml">网站地图</a>
                     </div>
                 </div>

--- a/loan-interest-calculator.html
+++ b/loan-interest-calculator.html
@@ -43,6 +43,10 @@
                     <i class="fas fa-calculator"></i>
                     <span>信用卡分期</span>
                 </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
             </nav>
             <h1 class="logo">
                 <i class="fas fa-coins"></i>
@@ -189,6 +193,7 @@
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>
+                        <li><a href="/card-bin-lookup.html">BIN 号查询工具</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -52,6 +52,14 @@
         <priority>0.8</priority>
     </url>
 
+    <!-- 银行卡 BIN 号查询工具 -->
+    <url>
+        <loc>https://yinhangka.online/card-bin-lookup.html</loc>
+        <lastmod>2024-04-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+
     <!-- 银行详情页面（动态生成） -->
     <url>
         <loc>https://yinhangka.online/banks/icbc.html</loc>

--- a/style.css
+++ b/style.css
@@ -46,7 +46,7 @@ body {
     padding: 8px;
     border: 1px solid rgba(255, 255, 255, 0.2);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-    max-width: 900px;
+    max-width: 1000px;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 2rem;
@@ -1294,6 +1294,235 @@ body {
     border-radius: 999px;
 }
 
+/* BIN 查询工具样式 */
+.bin-results-summary {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.bin-number {
+    font-size: 1.45rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #2d3748;
+}
+
+.bin-results-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #5a67d8;
+    background: rgba(102, 126, 234, 0.18);
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+}
+
+.bin-results-badge i {
+    font-size: 0.85rem;
+}
+
+.bin-detail-source {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+    color: #4a5568;
+    background: rgba(102, 126, 234, 0.12);
+    padding: 0.45rem 1rem;
+    border-radius: 999px;
+}
+
+.bin-detail-source i {
+    color: #5a67d8;
+}
+
+.bin-details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.bin-detail-item {
+    background: rgba(255, 255, 255, 0.94);
+    border-radius: 16px;
+    padding: 1.2rem 1.4rem;
+    border: 1px solid rgba(102, 126, 234, 0.25);
+    box-shadow: 0 18px 32px rgba(102, 126, 234, 0.16);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.bin-detail-item:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 36px rgba(102, 126, 234, 0.22);
+}
+
+.bin-detail-label {
+    display: block;
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #718096;
+    margin-bottom: 0.4rem;
+}
+
+.bin-detail-value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #2d3748;
+    word-break: break-word;
+    line-height: 1.4;
+}
+
+.bin-detail-value a {
+    color: #5a67d8;
+    text-decoration: none;
+}
+
+.bin-detail-value a:hover {
+    text-decoration: underline;
+}
+
+.bin-results-note {
+    margin-top: 1.3rem;
+    font-size: 0.92rem;
+    color: #4a5568;
+    line-height: 1.6;
+}
+
+.bin-note-list {
+    margin-top: 0.8rem;
+    padding-left: 1.2rem;
+    font-size: 0.9rem;
+    color: #4a5568;
+    line-height: 1.6;
+}
+
+.bin-note-list li {
+    margin-bottom: 0.35rem;
+}
+
+.bin-history-section {
+    margin-bottom: 4rem;
+}
+
+.bin-history-header {
+    text-align: center;
+    color: white;
+    margin-bottom: 2rem;
+}
+
+.bin-history-header p {
+    max-width: 740px;
+    margin: 0.75rem auto 0;
+    font-size: 1.05rem;
+    opacity: 0.85;
+    line-height: 1.8;
+}
+
+.bin-history-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.2rem;
+}
+
+.bin-history-item {
+    width: 100%;
+    border: none;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 18px;
+    padding: 1.2rem 1.4rem;
+    text-align: left;
+    box-shadow: 0 16px 34px rgba(31, 41, 55, 0.2);
+    border: 1px solid rgba(102, 126, 234, 0.25);
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.bin-history-item:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 36px rgba(102, 126, 234, 0.35);
+}
+
+.bin-history-item:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.25);
+}
+
+.bin-history-bin {
+    display: block;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #2d3748;
+    letter-spacing: 0.05em;
+}
+
+.bin-history-bank {
+    margin-top: 0.35rem;
+    font-size: 1rem;
+    color: #4a5568;
+    font-weight: 600;
+}
+
+.bin-history-meta {
+    margin-top: 0.2rem;
+    font-size: 0.9rem;
+    color: #5a67d8;
+    font-weight: 600;
+}
+
+.bin-history-source {
+    margin-top: 0.35rem;
+    font-size: 0.82rem;
+    color: #718096;
+}
+
+.bin-history-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 1.6rem;
+    border-radius: 18px;
+    border: 1px dashed rgba(255, 255, 255, 0.45);
+    color: white;
+    background: rgba(255, 255, 255, 0.08);
+    font-size: 1rem;
+}
+
+.bin-highlight {
+    color: #5a67d8;
+    font-weight: 600;
+}
+
+.bin-history-actions {
+    margin-top: 1.5rem;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.9rem;
+}
+
+.bin-history-actions button {
+    background: none;
+    border: none;
+    color: #ffd700;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: underline;
+    font-size: 0.95rem;
+}
+
+.bin-history-actions button:hover {
+    color: #fff5a1;
+}
+
 @media (max-width: 1024px) {
     .calculator-grid {
         grid-template-columns: 1fr;
@@ -1454,6 +1683,23 @@ body {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .bin-results-summary {
+        align-items: flex-start;
+        gap: 0.6rem 1rem;
+    }
+
+    .bin-details-grid {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .bin-history-header p {
+        font-size: 0.98rem;
+    }
+
+    .bin-history-list {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
     .tips-grid {
         grid-template-columns: 1fr;
     }
@@ -1516,6 +1762,23 @@ body {
         justify-content: center;
     }
 
+    .bin-results-summary {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .bin-number {
+        font-size: 1.3rem;
+    }
+
+    .bin-history-list {
+        grid-template-columns: 1fr;
+    }
+
+    .bin-history-item {
+        padding: 1rem 1.15rem;
+    }
+
     .info-card {
         padding: 1.4rem;
     }
@@ -1540,29 +1803,37 @@ body {
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
     }
-    
+
     .bank-card {
         margin: 0 5px;
         padding: 1rem;
     }
-    
+
     .bank-icon {
         width: 50px;
         height: 50px;
     }
-    
+
     .favicon-img {
         width: 30px;
         height: 30px;
         padding: 2px;
     }
-    
+
     .fallback-text {
         font-size: 1.2rem;
     }
-    
+
     .bank-name {
         font-size: 1.1rem;
+    }
+
+    .bin-detail-value {
+        font-size: 0.95rem;
+    }
+
+    .bin-history-item {
+        padding: 0.9rem 1rem;
     }
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,16 +1,18 @@
-const CACHE_NAME = 'bank-recommendation-v1.1.0';
+const CACHE_NAME = 'bank-recommendation-v1.2.0';
 const urlsToCache = [
   '/',
   '/index.html',
   '/style.css',
   '/script.js',
   '/calculators.js',
+  '/bin-lookup.js',
   '/manifest.json',
   '/global-banks.html',
   '/credit-cards.html',
   '/exchange-rates.html',
   '/loan-interest-calculator.html',
   '/credit-card-installment-calculator.html',
+  '/card-bin-lookup.html',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css'
 ];
 


### PR DESCRIPTION
## Summary
- add a dedicated bank card BIN lookup page with hero content, form, results panel, history and FAQ guidance
- implement bin-lookup.js to query the public BIN API, provide local fallbacks, render details and persist recent lookups
- update shared styling, navigation, caching metadata and docs so the new tool is available throughout the site

## Testing
- node -e "new Function(require('fs').readFileSync('bin-lookup.js', 'utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68d1f741006483219cbd90273997a634