### PR TITLE
Simplify header navigation layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -46,10 +46,6 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-credit-card"></i>
-                银行卡推荐网站
-            </h1>
         </div>
     </header>
 

--- a/card-bin-lookup.html
+++ b/card-bin-lookup.html
@@ -48,11 +48,6 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-barcode"></i>
-                银行卡 BIN 号查询工具
-            </h1>
-            <p class="subtitle">核实发卡行与卡种信息，保障支付安全</p>
         </div>
     </header>
 
@@ -74,7 +69,7 @@
             </nav>
 
             <section class="hero">
-                <h2 class="hero-title">输入 BIN 号，快速识别银行卡信息</h2>
+                <h1 class="hero-title">输入 BIN 号，快速识别银行卡信息</h1>
                 <p class="hero-description">
                     BIN（Bank Identification Number）是银行卡号的前 6-8 位，通过查询 BIN 号可以确认银行卡的发卡行、卡组织、卡种类型以及所属国家/地区，帮助您在支付前完成核验。
                 </p>

--- a/credit-card-installment-calculator.html
+++ b/credit-card-installment-calculator.html
@@ -48,11 +48,6 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-calculator"></i>
-                信用卡分期计算器
-            </h1>
-            <p class="subtitle">清晰了解每期本金与手续费，合理规划信用卡分期</p>
         </div>
     </header>
 
@@ -74,7 +69,7 @@
             </nav>
 
             <section class="hero">
-                <h2 class="hero-title">信用卡分期费用一目了然</h2>
+                <h1 class="hero-title">信用卡分期费用一目了然</h1>
                 <p class="hero-description">
                     输入分期金额、期数与每期手续费率，即可得知每期应还金额、累计手续费及折算年化费率，
                     帮助您快速判断分期成本是否合理。

--- a/credit-cards.html
+++ b/credit-cards.html
@@ -44,18 +44,13 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-credit-card"></i>
-                信用卡在线申请
-            </h1>
-            <p class="subtitle">快速申请全球知名银行信用卡</p>
         </div>
     </header>
 
     <main class="main">
         <div class="container">
             <section class="hero">
-                <h2 class="hero-title">信用卡在线申请</h2>
+                <h1 class="hero-title">信用卡在线申请</h1>
                 <p class="hero-description">
                     精选全球100家银行的信用卡产品，提供便捷的在线申请服务。
                     选择适合您的信用卡，享受优质的金融服务和专属权益。

--- a/exchange-rates.html
+++ b/exchange-rates.html
@@ -44,16 +44,16 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-chart-line"></i>
-                实时汇率查询
-            </h1>
-            <p class="subtitle">全球主要货币实时汇率转换</p>
         </div>
     </header>
 
     <main class="main">
         <div class="container">
+            <section class="hero">
+                <h1 class="hero-title">实时汇率查询</h1>
+                <p class="hero-description">全球主要货币实时汇率转换</p>
+            </section>
+
             <!-- 汇率转换器 -->
             <section class="converter-section">
                 <div class="converter-card">

--- a/faq.html
+++ b/faq.html
@@ -47,10 +47,6 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-credit-card"></i>
-                银行卡推荐网站
-            </h1>
         </div>
     </header>
 

--- a/favicon-demo.html
+++ b/favicon-demo.html
@@ -10,6 +10,14 @@
     <title>Favicon功能演示</title>
     <link rel="stylesheet" href="style.css">
     <style>
+        .demo-heading {
+            color: white;
+            font-size: 2.2rem;
+            margin-bottom: 2rem;
+            text-align: center;
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+        }
+
         .demo-section {
             margin: 2rem 0;
             padding: 2rem;
@@ -24,7 +32,7 @@
             margin-bottom: 1rem;
             text-align: center;
         }
-        
+
         .demo-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -50,16 +58,42 @@
 <body>
     <header class="header">
         <div class="container">
-            <h1 class="logo">
-                <i class="fas fa-credit-card"></i>
-                Favicon功能演示
-            </h1>
-            <p class="subtitle">展示各种favicon加载状态和降级处理</p>
+            <nav class="nav-menu">
+                <a href="index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
+            </nav>
         </div>
     </header>
 
     <main class="main">
         <div class="container">
+            <h1 class="demo-heading">Favicon 功能演示</h1>
             <div class="demo-section">
                 <h2 class="demo-title">✅ 成功加载的Favicon</h2>
                 <div class="demo-grid">

--- a/global-banks.html
+++ b/global-banks.html
@@ -44,18 +44,13 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-globe-americas"></i>
-                全球银行推荐
-            </h1>
-            <p class="subtitle">探索世界各地的知名银行服务</p>
         </div>
     </header>
 
     <main class="main">
         <div class="container">
             <section class="hero">
-                <h2 class="hero-title">全球金融服务</h2>
+                <h1 class="hero-title">全球金融服务</h1>
                 <p class="hero-description">
                     精选全球100家知名银行，涵盖北美、欧洲、亚太、中东非洲等地区，
                     为您提供全方位的国际金融服务信息。

--- a/index.html
+++ b/index.html
@@ -154,11 +154,6 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-credit-card"></i>
-                银行卡推荐网站
-            </h1>
-            <p class="subtitle">选择最适合您的银行服务</p>
         </div>
     </header>
 

--- a/loan-interest-calculator.html
+++ b/loan-interest-calculator.html
@@ -48,11 +48,6 @@
                     <span>BIN 查询</span>
                 </a>
             </nav>
-            <h1 class="logo">
-                <i class="fas fa-coins"></i>
-                贷款利率计算器
-            </h1>
-            <p class="subtitle">轻松计算房贷、车贷等多种贷款的月供与利息</p>
         </div>
     </header>
 
@@ -74,7 +69,7 @@
             </nav>
 
             <section class="hero">
-                <h2 class="hero-title">等额本息月供即时测算</h2>
+                <h1 class="hero-title">等额本息月供即时测算</h1>
                 <p class="hero-description">
                     输入贷款金额、年化利率与还款期限，即可获得详细的等额本息月供计算结果，
                     包括每月还款金额、利息支出、剩余本金以及前12期的还款计划预览。

--- a/style.css
+++ b/style.css
@@ -25,7 +25,7 @@ body {
     background: rgba(255, 255, 255, 0.1);
     backdrop-filter: blur(10px);
     border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-    padding: 2rem 0;
+    padding: 1.25rem 0;
     text-align: center;
     color: white;
     position: sticky;
@@ -38,8 +38,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 0;
-    margin-bottom: 2rem;
+    gap: 8px;
     background: rgba(255, 255, 255, 0.1);
     backdrop-filter: blur(20px);
     border-radius: 60px;
@@ -47,9 +46,8 @@ body {
     border: 1px solid rgba(255, 255, 255, 0.2);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
     max-width: 1000px;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 2rem;
+    margin: 0 auto;
+    flex-wrap: wrap;
 }
 
 .nav-link {
@@ -112,24 +110,6 @@ body {
 
 .nav-link.active i {
     color: #667eea;
-}
-
-.logo {
-    font-size: 2.5rem;
-    font-weight: bold;
-    margin-bottom: 0.5rem;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
-.logo i {
-    color: #ffd700;
-    margin-right: 0.5rem;
-}
-
-.subtitle {
-    font-size: 1.2rem;
-    opacity: 0.9;
-    font-weight: 300;
 }
 
 /* 主要内容 */
@@ -1586,14 +1566,14 @@ body {
     .container {
         padding: 0 15px;
     }
-    
+
     .nav-menu {
         flex-direction: row;
         flex-wrap: wrap;
         gap: 4px;
         padding: 6px;
         max-width: 100%;
-        margin-bottom: 1.5rem;
+        margin-bottom: 0;
     }
     
     .nav-link {
@@ -1611,10 +1591,6 @@ body {
     .nav-link i {
         margin: 0;
         font-size: 1.1rem;
-    }
-    
-    .logo {
-        font-size: 2rem;
     }
     
     .hero-title {


### PR DESCRIPTION
## Summary
- trim each page header so it only renders the navigation bar
- surface page-specific titles within the main hero content, including a new intro for the exchange rates page
- align the favicon demo with the shared navigation and a dedicated page heading

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d22ccc8cec8321b3a495372ac2fcf9