### PR TITLE
Add pages for certificate photo sizes, terms, and search

### DIFF
--- a/picturesize/index.html
+++ b/picturesize/index.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>证件照尺寸对照表与制作指南 - 银行卡推荐网站</title>
+    <meta name="description" content="详细整理常用证件照尺寸、像素大小与背景色要求，帮助您快速完成身份证、护照、签证等照片的制作与调整。">
+    <meta name="keywords" content="证件照尺寸,身份证照片,护照照片,签证照片,一寸照片尺寸,二寸照片尺寸,照片换背景">
+    <link rel="canonical" href="https://yinhangka.online/picturesize/">
+    <link rel="stylesheet" href="/style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="/index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="/global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="/credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="/exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="/loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="/credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+                <a href="/card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
+                <a href="/faq.html" class="nav-link">
+                    <i class="fas fa-circle-question"></i>
+                    <span>常见问题</span>
+                </a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item">
+                            <span itemprop="name">首页</span>
+                        </a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">证件照尺寸</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+
+            <section class="info-card info-card--accent">
+                <h1 class="section-title" style="text-align:left;color:#fff;">
+                    <i class="fas fa-id-card"></i>
+                    证件照尺寸对照表与制作指南
+                </h1>
+                <p>
+                    无论是身份证、护照、签证还是职业资格考试报名，规范的证件照都是必不可少的材料。以下内容汇总了最常用的证件照尺寸、像素要求与背景色规范，并提供实用的拍摄与后期调整建议，帮助您一次通过审核。
+                </p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-table"></i> 常用证件照尺寸对照表（300 DPI）</h2>
+                <div class="result-table-wrapper">
+                    <table class="result-table">
+                        <thead>
+                            <tr>
+                                <th>类型</th>
+                                <th>成品尺寸（毫米）</th>
+                                <th>像素尺寸</th>
+                                <th>常见背景色</th>
+                                <th>备注</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>一寸证件照</td>
+                                <td>25 × 35 mm</td>
+                                <td>295 × 413 px</td>
+                                <td>蓝、白、红</td>
+                                <td>身份证、校园卡常用</td>
+                            </tr>
+                            <tr>
+                                <td>小一寸证件照</td>
+                                <td>22 × 32 mm</td>
+                                <td>260 × 378 px</td>
+                                <td>蓝、白</td>
+                                <td>求职表格、部分简历</td>
+                            </tr>
+                            <tr>
+                                <td>大一寸证件照</td>
+                                <td>33 × 48 mm</td>
+                                <td>390 × 567 px</td>
+                                <td>蓝、白、灰</td>
+                                <td>教师资格、职业证书</td>
+                            </tr>
+                            <tr>
+                                <td>二寸证件照</td>
+                                <td>35 × 49 mm</td>
+                                <td>413 × 590 px</td>
+                                <td>蓝、白、红</td>
+                                <td>护照、签证通用尺寸</td>
+                            </tr>
+                            <tr>
+                                <td>中国普通护照</td>
+                                <td>33 × 48 mm</td>
+                                <td>354 × 472 px</td>
+                                <td>白色</td>
+                                <td>面部需占画面70%-80%</td>
+                            </tr>
+                            <tr>
+                                <td>港澳通行证</td>
+                                <td>33 × 48 mm</td>
+                                <td>390 × 567 px</td>
+                                <td>淡蓝或白色</td>
+                                <td>需露出双耳与眉毛</td>
+                            </tr>
+                            <tr>
+                                <td>美国签证（DS-160）</td>
+                                <td>51 × 51 mm</td>
+                                <td>600 × 600 px</td>
+                                <td>白色</td>
+                                <td>近六个月内拍摄</td>
+                            </tr>
+                            <tr>
+                                <td>申根签证</td>
+                                <td>35 × 45 mm</td>
+                                <td>413 × 531 px</td>
+                                <td>浅色背景</td>
+                                <td>面部居中，无阴影</td>
+                            </tr>
+                            <tr>
+                                <td>驾驶证体检照</td>
+                                <td>32 × 42 mm</td>
+                                <td>378 × 496 px</td>
+                                <td>白或浅蓝</td>
+                                <td>不佩戴眼镜与饰品</td>
+                            </tr>
+                            <tr>
+                                <td>社保证、医保卡</td>
+                                <td>26 × 32 mm</td>
+                                <td>307 × 378 px</td>
+                                <td>蓝、白</td>
+                                <td>头顶留白 3-5 mm</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-lightbulb"></i> 拍摄与调整小贴士</h2>
+                <div class="tips-grid">
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-camera"></i> 拍摄准备</h3>
+                        <ul>
+                            <li>选择充足自然光或柔光灯，避免脸部阴影。</li>
+                            <li>穿着纯色上衣，避免条纹、亮片等干扰元素。</li>
+                            <li>头发梳理整齐，确保眉毛、双耳清晰可见。</li>
+                        </ul>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-crop"></i> 尺寸裁切</h3>
+                        <ul>
+                            <li>使用 Photoshop、Photopea 等工具设置 DPI 为 300。</li>
+                            <li>按照上表输入像素宽高，确保纵横比准确。</li>
+                            <li>保留头顶与下巴留白范围，避免被裁切。</li>
+                        </ul>
+                    </div>
+                    <div class="info-card info-card--outline">
+                        <h3><i class="fas fa-magic"></i> 背景处理</h3>
+                        <ul>
+                            <li>使用 remove.bg、稿定设计等线上工具抠图换背景。</li>
+                            <li>保持背景颜色均匀，无明显色块与噪点。</li>
+                            <li>导出 JPG 或 PNG 时控制文件大小在 100 KB 以内（如有要求）。</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-download"></i> 常见在线工具推荐</h2>
+                <ul>
+                    <li>公安部互联网+政务服务证件照工具</li>
+                    <li>国家政务服务平台「证件照智能助手」小程序</li>
+                    <li>稿定设计、醒图等支持快速换底色的移动应用</li>
+                    <li>Photopea：网页版 Photoshop，支持在线裁剪与调色</li>
+                </ul>
+                <p style="margin-top:1rem;">
+                    如果需要批量处理证件照，可选择具有批量裁切、背景替换功能的桌面软件，并提前根据用途核对尺寸要求。
+                </p>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>关于我们</h4>
+                    <p>为您提供最全面的银行服务信息，助您选择最适合的银行产品。</p>
+                </div>
+                <div class="footer-section">
+                    <h4>服务特色</h4>
+                    <ul>
+                        <li>全面的银行信息</li>
+                        <li>实时官网链接</li>
+                        <li>一键拨打客服电话</li>
+                        <li>专业的推荐服务</li>
+                        <li>安全可靠的跳转</li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>联系我们</h4>
+                    <p>如有任何问题或建议，请随时与我们联系。</p>
+                    <div class="footer-links">
+                        <a href="/about.html">关于我们</a>
+                        <a href="/contact.html">联系我们</a>
+                        <a href="/privacy.html">隐私政策</a>
+                        <a href="/terms.html">服务条款</a>
+                        <a href="/faq.html">常见问题</a>
+                        <a href="/loan-interest-calculator.html">贷款利率计算器</a>
+                        <a href="/credit-card-installment-calculator.html">信用卡分期计算器</a>
+                        <a href="/card-bin-lookup.html">BIN 号查询工具</a>
+                        <a href="/sitemap.xml">网站地图</a>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 银行卡推荐网站. 保留所有权利。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="/script.js"></script>
+</body>
+</html>

--- a/search/index.html
+++ b/search/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>站内搜索 - 银行卡推荐网站</title>
+    <meta name="description" content="通过站内搜索快速找到银行卡推荐网站的银行资讯、信用卡攻略、金融工具与使用指南。">
+    <meta name="robots" content="noindex, follow">
+    <link rel="canonical" href="https://yinhangka.online/search/">
+    <link rel="stylesheet" href="/style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="/index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="/global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="/credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="/exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="/loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="/credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+                <a href="/card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
+                <a href="/faq.html" class="nav-link">
+                    <i class="fas fa-circle-question"></i>
+                    <span>常见问题</span>
+                </a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item">
+                            <span itemprop="name">首页</span>
+                        </a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">站内搜索</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+
+            <section class="info-card info-card--accent">
+                <h1 class="section-title" style="text-align:left;color:#fff;">
+                    <i class="fas fa-search"></i>
+                    站内搜索中心
+                </h1>
+                <p>
+                    输入关键词即可快速浏览本站整理的银行信息、信用卡申请攻略、金融工具与帮助文章，助您高效找到需要的内容。
+                </p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-keyboard"></i> 搜索关键词</h2>
+                <form id="site-search-form" class="search-box" role="search" aria-label="站内搜索">
+                    <input type="search" id="search-input" name="q" class="search-input" placeholder="例如：招商银行信用卡、证件照尺寸、汇率工具" aria-label="输入要搜索的内容">
+                    <i class="fas fa-search search-icon" aria-hidden="true"></i>
+                </form>
+                <p class="search-hint">
+                    小提示：可以输入银行名称、金融工具名称或具体问题，例如“信用卡分期计算器”“证件照尺寸”“BIN 查询”。
+                </p>
+            </section>
+
+            <section class="info-card">
+                <div class="search-result-header">
+                    <h2><i class="fas fa-list"></i> 搜索结果</h2>
+                    <span id="result-count" class="search-result-count"></span>
+                </div>
+                <div id="search-results" class="search-result-container" aria-live="polite"></div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>关于我们</h4>
+                    <p>为您提供最全面的银行服务信息，助您选择最适合的银行产品。</p>
+                </div>
+                <div class="footer-section">
+                    <h4>服务特色</h4>
+                    <ul>
+                        <li>全面的银行信息</li>
+                        <li>实时官网链接</li>
+                        <li>一键拨打客服电话</li>
+                        <li>专业的推荐服务</li>
+                        <li>安全可靠的跳转</li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>联系我们</h4>
+                    <p>如有任何问题或建议，请随时与我们联系。</p>
+                    <div class="footer-links">
+                        <a href="/about.html">关于我们</a>
+                        <a href="/contact.html">联系我们</a>
+                        <a href="/privacy.html">隐私政策</a>
+                        <a href="/terms.html">服务条款</a>
+                        <a href="/faq.html">常见问题</a>
+                        <a href="/loan-interest-calculator.html">贷款利率计算器</a>
+                        <a href="/credit-card-installment-calculator.html">信用卡分期计算器</a>
+                        <a href="/card-bin-lookup.html">BIN 号查询工具</a>
+                        <a href="/sitemap.xml">网站地图</a>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 银行卡推荐网站. 保留所有权利。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const pageData = [
+            {
+                title: '国内银行速览',
+                description: '覆盖工商银行、建设银行、招商银行等国内主要银行的客服电话、官网链接与业务特色。',
+                url: '/index.html',
+                keywords: ['国内银行', '客服电话', '银行官网', '银行产品']
+            },
+            {
+                title: '全球银行与国际账户指南',
+                description: '了解花旗银行、汇丰银行等国际银行的业务范围、开户建议与跨境服务。',
+                url: '/global-banks.html',
+                keywords: ['全球银行', '跨境金融', '国际账户']
+            },
+            {
+                title: '热门信用卡申请攻略',
+                description: '对比国内热门信用卡权益、申请条件与提额技巧，帮您选择合适的信用卡。',
+                url: '/credit-cards.html',
+                keywords: ['信用卡申请', '信用卡权益', '信用卡对比']
+            },
+            {
+                title: '实时汇率查询工具',
+                description: '支持多种货币实时汇率换算，提供常见货币的历史走势与换汇提示。',
+                url: '/exchange-rates.html',
+                keywords: ['汇率', '货币换算', '外汇']
+            },
+            {
+                title: '贷款利率计算器',
+                description: '输入贷款金额、年限与利率即可快速计算月供、总利息与还款计划。',
+                url: '/loan-interest-calculator.html',
+                keywords: ['贷款计算', '房贷', '月供']
+            },
+            {
+                title: '信用卡分期计算器',
+                description: '评估信用卡分期的手续费与每期应还金额，合理规划消费预算。',
+                url: '/credit-card-installment-calculator.html',
+                keywords: ['信用卡分期', '手续费', '消费计划']
+            },
+            {
+                title: '银行卡 BIN 号查询',
+                description: '通过卡号前六位识别发卡行、卡种类型与所属地区，防范风险交易。',
+                url: '/card-bin-lookup.html',
+                keywords: ['BIN 查询', '卡号识别', '发卡行']
+            },
+            {
+                title: '常见问题解答',
+                description: '整理信用卡申请、储蓄卡办理、银行业务等常见问题的解决方案。',
+                url: '/faq.html',
+                keywords: ['常见问题', '信用卡问题', '储蓄卡问题']
+            },
+            {
+                title: '证件照尺寸对照表与制作指南',
+                description: '提供一寸、二寸、护照、签证等证件照尺寸、像素与背景色标准，附带拍摄技巧。',
+                url: '/picturesize/',
+                keywords: ['证件照尺寸', '护照照片', '签证照片', '照片背景']
+            },
+            {
+                title: '服务条款',
+                description: '了解本站的服务范围、免责声明、用户责任与隐私保护承诺。',
+                url: '/terms.html',
+                keywords: ['服务条款', '用户责任', '免责声明']
+            }
+        ];
+
+        const form = document.getElementById('site-search-form');
+        const input = document.getElementById('search-input');
+        const resultsContainer = document.getElementById('search-results');
+        const resultCount = document.getElementById('result-count');
+
+        function sanitize(text) {
+            return text.replace(/[.*+?^${}()|[\]\]/g, '\$&');
+        }
+
+        function highlight(text, query) {
+            if (!query) return text;
+            const pattern = new RegExp(`(${sanitize(query)})`, 'gi');
+            return text.replace(pattern, '<mark>$1</mark>');
+        }
+
+        function renderResults(list, query) {
+            resultsContainer.innerHTML = '';
+            if (!list.length) {
+                resultCount.textContent = '未找到匹配内容';
+                const empty = document.createElement('div');
+                empty.className = 'no-results';
+                empty.innerHTML = '<i class="fas fa-info-circle"></i> 未找到相关内容，请尝试使用其他关键词。';
+                resultsContainer.appendChild(empty);
+                return;
+            }
+
+            resultCount.textContent = `共找到 ${list.length} 条结果`;
+
+            list.forEach(item => {
+                const card = document.createElement('article');
+                card.className = 'search-result-card';
+
+                const title = document.createElement('h3');
+                title.innerHTML = highlight(item.title, query);
+                card.appendChild(title);
+
+                const desc = document.createElement('p');
+                desc.innerHTML = highlight(item.description, query);
+                card.appendChild(desc);
+
+                const meta = document.createElement('div');
+                meta.className = 'search-result-meta';
+                meta.textContent = item.url;
+                card.appendChild(meta);
+
+                const link = document.createElement('a');
+                link.href = item.url;
+                link.className = 'search-result-link';
+                link.innerHTML = '前往查看 <i class="fas fa-arrow-right"></i>';
+                card.appendChild(link);
+
+                resultsContainer.appendChild(card);
+            });
+        }
+
+        function performSearch(query) {
+            const keyword = query.trim();
+            if (!keyword) {
+                resultCount.textContent = '请输入关键词开始搜索';
+                resultsContainer.innerHTML = '<div class="no-results"><i class="fas fa-lightbulb"></i> 可尝试输入“信用卡申请”“证件照尺寸”“汇率计算”等关键词。</div>';
+                return;
+            }
+
+            const lowered = keyword.toLowerCase();
+            const matches = pageData.filter(item => {
+                const text = [item.title, item.description, ...(item.keywords || [])].join(' ').toLowerCase();
+                return text.includes(lowered);
+            });
+
+            renderResults(matches, keyword);
+        }
+
+        input.addEventListener('input', () => {
+            performSearch(input.value || '');
+        });
+
+        form.addEventListener('submit', event => {
+            event.preventDefault();
+            const value = input.value;
+            const params = new URLSearchParams(window.location.search);
+            if (value) {
+                params.set('q', value.trim());
+            } else {
+                params.delete('q');
+            }
+            const newUrl = `${window.location.pathname}?${params.toString()}`.replace(/\?$/, '');
+            window.history.replaceState(null, '', newUrl);
+            performSearch(value || '');
+        });
+
+        const params = new URLSearchParams(window.location.search);
+        const initialQuery = params.get('q') || '';
+        if (initialQuery) {
+            input.value = initialQuery;
+        }
+        performSearch(initialQuery);
+    </script>
+    <script src="/script.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -67,6 +67,27 @@
     </url>
 
     <url>
+        <loc>https://yinhangka.online/picturesize/</loc>
+        <lastmod>2025-09-29</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+
+    <url>
+        <loc>https://yinhangka.online/terms.html</loc>
+        <lastmod>2025-09-29</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.4</priority>
+    </url>
+
+    <url>
+        <loc>https://yinhangka.online/search/</loc>
+        <lastmod>2025-09-29</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+    <url>
         <loc>https://yinhangka.online/favicon-demo.html</loc>
         <lastmod>2025-09-23</lastmod>
         <changefreq>yearly</changefreq>

--- a/style.css
+++ b/style.css
@@ -1974,6 +1974,112 @@ body {
     font-size: 1.2rem;
 }
 
+.search-hint {
+    margin-top: 1rem;
+    color: rgba(255, 255, 255, 0.8);
+    text-align: center;
+    line-height: 1.7;
+}
+
+.search-result-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.search-result-count {
+    font-size: 0.95rem;
+    color: rgba(74, 85, 104, 0.9);
+    background: rgba(255, 255, 255, 0.85);
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(102, 126, 234, 0.25);
+}
+
+.search-result-container {
+    margin-top: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.search-result-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+    border: 1px solid rgba(102, 126, 234, 0.18);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.search-result-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 38px rgba(102, 126, 234, 0.25);
+}
+
+.search-result-card h3 {
+    font-size: 1.2rem;
+    color: #2d3748;
+}
+
+.search-result-card p {
+    color: #4a5568;
+    line-height: 1.7;
+}
+
+.search-result-meta {
+    font-size: 0.85rem;
+    color: rgba(74, 85, 104, 0.7);
+    word-break: break-all;
+}
+
+.search-result-link {
+    margin-top: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #667eea;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.search-result-link:hover {
+    transform: translateX(4px);
+    color: #5a67d8;
+}
+
+.search-result-link i {
+    font-size: 0.9rem;
+}
+
+.no-results {
+    padding: 1.2rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.9);
+    text-align: center;
+    color: #4a5568;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
+    border: 1px dashed rgba(102, 126, 234, 0.3);
+    line-height: 1.7;
+}
+
+.no-results i {
+    color: #667eea;
+    margin-right: 0.4rem;
+}
+
+mark {
+    background: #fff3bf;
+    color: inherit;
+    padding: 0 0.2rem;
+    border-radius: 4px;
+}
+
 /* 页脚链接 */
 .footer-links {
     display: flex;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bank-recommendation-v1.3.0';
+const CACHE_NAME = 'bank-recommendation-v1.4.0';
 const PRECACHE_URLS = [
   '/',
   '/index.html',
@@ -14,6 +14,9 @@ const PRECACHE_URLS = [
   '/credit-card-installment-calculator.html',
   '/card-bin-lookup.html',
   '/faq.html',
+  '/picturesize/index.html',
+  '/terms.html',
+  '/search/index.html',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css'
 ];
 

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>服务条款 - 银行卡推荐网站</title>
+    <meta name="description" content="阅读银行卡推荐网站的使用条款、免责声明、隐私保护与用户权利义务说明，了解本站服务范围与责任界定。">
+    <link rel="canonical" href="https://yinhangka.online/terms.html">
+    <link rel="stylesheet" href="/style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="/index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="/global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="/credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡申请</span>
+                </a>
+                <a href="/exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="/loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="/credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+                <a href="/card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
+                <a href="/faq.html" class="nav-link">
+                    <i class="fas fa-circle-question"></i>
+                    <span>常见问题</span>
+                </a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item">
+                            <span itemprop="name">首页</span>
+                        </a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">服务条款</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+
+            <section class="info-card info-card--accent">
+                <h1 class="section-title" style="text-align:left;color:#fff;">
+                    <i class="fas fa-scale-balanced"></i>
+                    服务条款
+                </h1>
+                <p>
+                    欢迎访问银行卡推荐网站（以下简称“本站”）。在使用本站提供的任何服务之前，请仔细阅读以下条款。当您访问或使用本站时，表示您已了解并同意遵守本服务条款。
+                </p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-circle-info"></i> 1. 服务说明</h2>
+                <p>本站提供有关银行产品、信用卡、储蓄卡、汇率与金融工具的资讯整理、技巧分享与在线工具。本站不直接提供任何金融产品的办理服务，所有申请、开户及金融交易均需通过相关银行或官方渠道完成。</p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-bullhorn"></i> 2. 免责声明</h2>
+                <ul>
+                    <li>本站发布的银行利率、优惠活动等信息来源于公开渠道，我们将尽力保持准确与及时，但不保证信息的完全正确性与实时性。</li>
+                    <li>因使用本站信息而产生的任何直接或间接损失，本站概不承担法律责任。建议在做出重要决策前，向银行客服或专业人士进一步核实。</li>
+                    <li>如因不可抗力、网络故障等原因造成服务中断或数据丢失，本站不承担赔偿责任，但会尽力恢复服务。</li>
+                </ul>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-user-shield"></i> 3. 用户责任</h2>
+                <ul>
+                    <li>用户在使用本站在线工具或留言反馈时，应提供真实、准确的信息，不得冒充他人或发布违法内容。</li>
+                    <li>禁止利用本站进行任何可能损害网络安全、侵犯他人权利或扰乱公共秩序的行为。</li>
+                    <li>用户应妥善保管个人设备与网络账号，对自身操作行为负责。</li>
+                </ul>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-shield-halved"></i> 4. 隐私保护</h2>
+                <p>本站重视用户隐私，遵守相关法律法规。关于我们如何收集、使用、存储与保护个人信息，请参阅《隐私政策》。除法律法规另有规定或用户授权，本站不会向第三方披露用户个人信息。</p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-copyright"></i> 5. 知识产权</h2>
+                <ul>
+                    <li>本站上的文字、图表、图标、界面设计及程序代码等内容受著作权法保护，未经授权禁止复制、转载或用于商业用途。</li>
+                    <li>引用第三方资料时，我们会标注来源或遵循相应授权协议。如您认为本站内容涉及侵权，请及时联系我们处理。</li>
+                </ul>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-handshake"></i> 6. 第三方链接</h2>
+                <p>本站可能包含指向银行官网或其他第三方网站的链接。这些链接仅为用户提供便利，本站对第三方网站的内容、安全性或可用性不承担责任。访问第三方网站时，请遵守其服务条款与隐私政策。</p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-file-signature"></i> 7. 条款修改</h2>
+                <p>本站保留根据运营需求、法律法规变化而更新服务条款的权利。修改后的条款将在页面上发布，并注明更新时间；继续使用本站即视为接受调整后的条款。</p>
+            </section>
+
+            <section class="info-card">
+                <h2><i class="fas fa-envelope"></i> 8. 联系我们</h2>
+                <p>如您对本服务条款有任何疑问、建议或投诉，可通过页脚中的联系方式与我们取得联系，我们将在合理时间内答复处理。</p>
+                <p style="margin-top:1rem;">最近更新日期：2025年9月29日</p>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>关于我们</h4>
+                    <p>为您提供最全面的银行服务信息，助您选择最适合的银行产品。</p>
+                </div>
+                <div class="footer-section">
+                    <h4>服务特色</h4>
+                    <ul>
+                        <li>全面的银行信息</li>
+                        <li>实时官网链接</li>
+                        <li>一键拨打客服电话</li>
+                        <li>专业的推荐服务</li>
+                        <li>安全可靠的跳转</li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>联系我们</h4>
+                    <p>如有任何问题或建议，请随时与我们联系。</p>
+                    <div class="footer-links">
+                        <a href="/about.html">关于我们</a>
+                        <a href="/contact.html">联系我们</a>
+                        <a href="/privacy.html">隐私政策</a>
+                        <a href="/terms.html">服务条款</a>
+                        <a href="/faq.html">常见问题</a>
+                        <a href="/loan-interest-calculator.html">贷款利率计算器</a>
+                        <a href="/credit-card-installment-calculator.html">信用卡分期计算器</a>
+                        <a href="/card-bin-lookup.html">BIN 号查询工具</a>
+                        <a href="/sitemap.xml">网站地图</a>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 银行卡推荐网站. 保留所有权利。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a certificate photo size guide with detailed measurements, tips, and tooling recommendations
- publish a terms of service page and register all new URLs in the sitemap and service worker cache
- add a site search page with client-side filtering, highlighting, and supporting styles for result cards

## Testing
- not run (static content updates)


------
https://chatgpt.com/codex/tasks/task_e_68da32817dbc8321baed0823c383271e