### PR TITLE
Revamp homepage hero and rename credit card navigation label

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,7 +27,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -79,7 +79,7 @@
                     <div class="error-suggestions">
                         <h3>您可能感兴趣的内容：</h3>
                         <ul>
-                            <li><a href="/credit-cards.html">信用卡申请</a></li>
+                            <li><a href="/credit-cards.html">信用卡</a></li>
                             <li><a href="/global-banks.html">全球银行</a></li>
                             <li><a href="/faq.html">常见问题</a></li>
                             <li><a href="/about.html">关于我们</a></li>
@@ -101,7 +101,7 @@
                     <h4>快速链接</h4>
                     <ul>
                         <li><a href="/">首页</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/global-banks.html">全球银行</a></li>
                         <li><a href="/faq.html">常见问题</a></li>
                     </ul>

--- a/bank-details.html
+++ b/bank-details.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/abc.html
+++ b/bank-pages/abc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/baixin.html
+++ b/bank-pages/baixin.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/baoshang.html
+++ b/bank-pages/baoshang.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/bea.html
+++ b/bank-pages/bea.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/beibuwan.html
+++ b/bank-pages/beibuwan.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/beijing.html
+++ b/bank-pages/beijing.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/boc.html
+++ b/bank-pages/boc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/bohai.html
+++ b/bank-pages/bohai.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/ccb.html
+++ b/bank-pages/ccb.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/ceb.html
+++ b/bank-pages/ceb.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/cgb.html
+++ b/bank-pages/cgb.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/changan.html
+++ b/bank-pages/changan.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/changsha.html
+++ b/bank-pages/changsha.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/cib.html
+++ b/bank-pages/cib.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/citibank.html
+++ b/bank-pages/citibank.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/citic.html
+++ b/bank-pages/citic.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/cmb.html
+++ b/bank-pages/cmb.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/cmbc.html
+++ b/bank-pages/cmbc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/dalian.html
+++ b/bank-pages/dalian.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/dongguanrcc.html
+++ b/bank-pages/dongguanrcc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/fujianrcc.html
+++ b/bank-pages/fujianrcc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/gansu.html
+++ b/bank-pages/gansu.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/guangzhou.html
+++ b/bank-pages/guangzhou.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/guizhou.html
+++ b/bank-pages/guizhou.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/hangzhou.html
+++ b/bank-pages/hangzhou.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/harbin.html
+++ b/bank-pages/harbin.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/hengfeng.html
+++ b/bank-pages/hengfeng.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/hsbc.html
+++ b/bank-pages/hsbc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/huaxia.html
+++ b/bank-pages/huaxia.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/hubei.html
+++ b/bank-pages/hubei.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/icbc.html
+++ b/bank-pages/icbc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/jiangnanrcc.html
+++ b/bank-pages/jiangnanrcc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/jiangsurn.html
+++ b/bank-pages/jiangsurn.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/jiangxi.html
+++ b/bank-pages/jiangxi.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/jilin.html
+++ b/bank-pages/jilin.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/jinshang.html
+++ b/bank-pages/jinshang.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/jiujiang.html
+++ b/bank-pages/jiujiang.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/kunlun.html
+++ b/bank-pages/kunlun.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/mengshang.html
+++ b/bank-pages/mengshang.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/mintai.html
+++ b/bank-pages/mintai.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/nanjing.html
+++ b/bank-pages/nanjing.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/neimenggu.html
+++ b/bank-pages/neimenggu.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/ningbo.html
+++ b/bank-pages/ningbo.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/pingan.html
+++ b/bank-pages/pingan.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/psbc.html
+++ b/bank-pages/psbc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/qilu.html
+++ b/bank-pages/qilu.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/rizhao.html
+++ b/bank-pages/rizhao.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/shanghai.html
+++ b/bank-pages/shanghai.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/shengjing.html
+++ b/bank-pages/shengjing.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/shenzhenrcc.html
+++ b/bank-pages/shenzhenrcc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/sichuanrcu.html
+++ b/bank-pages/sichuanrcu.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/spdb.html
+++ b/bank-pages/spdb.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/standardchartered.html
+++ b/bank-pages/standardchartered.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/suzhourcc.html
+++ b/bank-pages/suzhourcc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/tailong.html
+++ b/bank-pages/tailong.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/tianfu.html
+++ b/bank-pages/tianfu.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/wuxircc.html
+++ b/bank-pages/wuxircc.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/yunnanrcu.html
+++ b/bank-pages/yunnanrcu.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/zheshang.html
+++ b/bank-pages/zheshang.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/bank-pages/zhongyuan.html
+++ b/bank-pages/zhongyuan.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="../exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/card-bin-lookup.html
+++ b/card-bin-lookup.html
@@ -29,7 +29,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -180,7 +180,7 @@
                     <h4>快捷入口</h4>
                     <ul>
                         <li><a href="/index.html">国内银行</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>

--- a/credit-card-installment-calculator.html
+++ b/credit-card-installment-calculator.html
@@ -29,7 +29,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -185,7 +185,7 @@
                     <h4>快捷入口</h4>
                     <ul>
                         <li><a href="/index.html">国内银行</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>

--- a/credit-cards.html
+++ b/credit-cards.html
@@ -25,7 +25,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link active">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/exchange-rates.html
+++ b/exchange-rates.html
@@ -25,7 +25,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link active">
                     <i class="fas fa-exchange-alt"></i>

--- a/faq.html
+++ b/faq.html
@@ -28,7 +28,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -229,7 +229,7 @@
                     <h4>快速链接</h4>
                     <ul>
                         <li><a href="/">首页</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/global-banks.html">全球银行</a></li>
                         <li><a href="/about.html">关于我们</a></li>
                     </ul>

--- a/favicon-demo.html
+++ b/favicon-demo.html
@@ -69,7 +69,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/generate_bank_pages.py
+++ b/generate_bank_pages.py
@@ -64,7 +64,7 @@ def render_page(slug, data):
                 </a>
                 <a href=\"../credit-cards.html\" class=\"nav-link\">
                     <i class=\"fas fa-credit-card\"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href=\"../exchange-rates.html\" class=\"nav-link\">
                     <i class=\"fas fa-exchange-alt\"></i>

--- a/global-banks.html
+++ b/global-banks.html
@@ -25,7 +25,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -184,15 +184,40 @@
             </nav>
             
             <section class="hero">
-                <h1 class="hero-title">发现最佳银行服务</h1>
-                <p class="hero-description">
-                    我们为您精选了国内外知名银行，点击下方银行卡片即可直达官方网站，
-                    了解最新的银行卡产品和金融服务。
-                </p>
-                <!-- 搜索框 -->
-                <div class="search-box">
-                    <input type="search" id="bank-search" class="search-input" placeholder="搜索银行或信用卡..." aria-label="搜索银行">
-                    <i class="fas fa-search search-icon"></i>
+                <div class="hero-grid">
+                    <div class="hero-content">
+                        <span class="hero-badge"><i class="fas fa-star" aria-hidden="true"></i> 2024 精选推荐</span>
+                        <h1 class="hero-title">发现最佳银行服务</h1>
+                        <p class="hero-description">
+                            我们为您精选国内外优质银行与信用卡产品，提供最新的优惠活动、权益对比与办理攻略，帮助您快速锁定心仪的金融服务。
+                        </p>
+                        <ul class="hero-highlights" aria-label="服务亮点">
+                            <li><i class="fas fa-check-circle" aria-hidden="true"></i> 覆盖 80+ 家国内主流银行</li>
+                            <li><i class="fas fa-gift" aria-hidden="true"></i> 实时更新新户礼与热门权益</li>
+                            <li><i class="fas fa-shield-alt" aria-hidden="true"></i> 官方链接直达，安全办理</li>
+                        </ul>
+                        <!-- 搜索框 -->
+                        <div class="search-box hero-search">
+                            <input type="search" id="bank-search" class="search-input" placeholder="搜索银行或信用卡..." aria-label="搜索银行">
+                            <i class="fas fa-search search-icon" aria-hidden="true"></i>
+                        </div>
+                        <p class="hero-hint">输入银行或信用卡名称，即可快速查看详细介绍、联系方式与申请入口。</p>
+                    </div>
+                    <div class="hero-visual" aria-hidden="true">
+                        <div class="hero-card">
+                            <div class="hero-card-header">
+                                <span class="hero-card-badge">智能推荐</span>
+                                <span class="hero-card-icon"><i class="fas fa-chart-line"></i></span>
+                            </div>
+                            <p class="hero-card-text">多维度匹配最适合您的银行产品，实时掌握优惠与额度信息。</p>
+                            <ul class="hero-card-list">
+                                <li><i class="fas fa-check"></i> 信用卡权益对比</li>
+                                <li><i class="fas fa-check"></i> 银行最新公告</li>
+                                <li><i class="fas fa-check"></i> 个性化办理建议</li>
+                            </ul>
+                        </div>
+                        <div class="hero-gradient"></div>
+                    </div>
                 </div>
             </section>
 

--- a/loan-interest-calculator.html
+++ b/loan-interest-calculator.html
@@ -29,7 +29,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -192,7 +192,7 @@
                     <h4>快捷入口</h4>
                     <ul>
                         <li><a href="/index.html">国内银行</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>

--- a/math-calculator.html
+++ b/math-calculator.html
@@ -29,7 +29,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -228,7 +228,7 @@
                     <h4>快捷入口</h4>
                     <ul>
                         <li><a href="/index.html">国内银行</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>

--- a/picturesize/index.html
+++ b/picturesize/index.html
@@ -24,7 +24,7 @@
                 </a>
                 <a href="/credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="/exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/rmb-uppercase.html
+++ b/rmb-uppercase.html
@@ -29,7 +29,7 @@
                 </a>
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>
@@ -199,7 +199,7 @@
                     <h4>快捷入口</h4>
                     <ul>
                         <li><a href="/index.html">国内银行</a></li>
-                        <li><a href="/credit-cards.html">信用卡申请</a></li>
+                        <li><a href="/credit-cards.html">信用卡</a></li>
                         <li><a href="/exchange-rates.html">实时汇率</a></li>
                         <li><a href="/loan-interest-calculator.html">贷款利率计算器</a></li>
                         <li><a href="/credit-card-installment-calculator.html">信用卡分期计算器</a></li>

--- a/search/index.html
+++ b/search/index.html
@@ -24,7 +24,7 @@
                 </a>
                 <a href="/credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="/exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>

--- a/style.css
+++ b/style.css
@@ -119,24 +119,218 @@ body {
 
 /* 英雄区域 */
 .hero {
-    text-align: center;
-    margin-bottom: 4rem;
+    margin-bottom: 4.5rem;
     color: white;
+    text-align: center;
+}
+
+.hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    align-items: center;
+    gap: 3.5rem;
+}
+
+.hero-content {
+    text-align: left;
+}
+
+.hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1.2rem;
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 999px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 10px 30px rgba(102, 126, 234, 0.35);
+}
+
+.hero-badge i {
+    color: #ffd15c;
 }
 
 .hero-title {
-    font-size: 3rem;
-    font-weight: bold;
+    font-size: 3.2rem;
+    font-weight: 800;
     margin-bottom: 1rem;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .hero-description {
-    font-size: 1.3rem;
-    max-width: 800px;
+    font-size: 1.2rem;
+    max-width: 620px;
+    opacity: 0.92;
+    line-height: 1.9;
     margin: 0 auto;
-    opacity: 0.9;
-    line-height: 1.8;
+}
+
+.hero-content .hero-description {
+    margin: 0;
+}
+
+.hero-highlights {
+    list-style: none;
+    margin: 1.8rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+}
+
+.hero-highlights li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: rgba(255, 255, 255, 0.12);
+    padding: 0.75rem 1.1rem;
+    border-radius: 16px;
+    font-size: 1rem;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+}
+
+.hero-highlights i {
+    color: #9be7ff;
+    font-size: 1.1rem;
+}
+
+.hero-search {
+    margin: 2rem 0 1rem;
+}
+
+.hero-hint {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.82);
+}
+
+.hero-visual {
+    position: relative;
+    display: grid;
+    place-items: center;
+}
+
+.hero-card {
+    position: relative;
+    z-index: 2;
+    width: min(100%, 360px);
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 24px;
+    padding: 2.2rem;
+    box-shadow: 0 25px 55px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(14px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.hero-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+}
+
+.hero-card-badge {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.hero-card-icon {
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.8), rgba(118, 75, 162, 0.8));
+    color: #fff;
+    box-shadow: 0 12px 30px rgba(102, 126, 234, 0.35);
+}
+
+.hero-card-text {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.hero-card-list {
+    list-style: none;
+    margin: 1.5rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.7rem;
+}
+
+.hero-card-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.hero-card-list i {
+    width: 26px;
+    height: 26px;
+    border-radius: 999px;
+    display: grid;
+    place-items: center;
+    background: rgba(102, 126, 234, 0.25);
+    color: #fff;
+}
+
+.hero-gradient {
+    position: absolute;
+    inset: 15% -15% -10% -10%;
+    background: radial-gradient(circle at top right, rgba(155, 231, 255, 0.6), transparent 55%),
+                radial-gradient(circle at bottom left, rgba(255, 214, 92, 0.55), transparent 60%),
+                linear-gradient(135deg, rgba(102, 126, 234, 0.35), rgba(118, 75, 162, 0.45));
+    filter: blur(0px);
+    border-radius: 50%;
+    opacity: 0.85;
+    z-index: 1;
+}
+
+@media (max-width: 1024px) {
+    .hero-grid {
+        grid-template-columns: 1fr;
+        gap: 2.5rem;
+    }
+
+    .hero-content {
+        text-align: center;
+    }
+
+    .hero-description {
+        margin: 0 auto;
+    }
+
+    .hero-highlights {
+        justify-items: center;
+    }
+
+    .hero-highlights li {
+        justify-content: center;
+    }
+
+    .hero-search {
+        margin: 2rem auto 1rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .hero-title {
+        font-size: 2.4rem;
+    }
+
+    .hero-card {
+        padding: 1.8rem;
+    }
+
+    .hero-highlights li {
+        font-size: 0.95rem;
+    }
 }
 
 /* 银行区域 */
@@ -160,9 +354,9 @@ body {
 /* 银行卡片网格 */
 .banks-grid {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 1.5rem;
-    margin-top: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.8rem;
+    margin-top: 2.2rem;
 }
 
 /* 银行卡片 */

--- a/terms.html
+++ b/terms.html
@@ -23,7 +23,7 @@
                 </a>
                 <a href="/credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
-                    <span>信用卡申请</span>
+                    <span>信用卡</span>
                 </a>
                 <a href="/exchange-rates.html" class="nav-link">
                     <i class="fas fa-exchange-alt"></i>


### PR DESCRIPTION
## Summary
- redesign the homepage hero with a new two-column layout, feature highlights, and a glassmorphism-style recommendation card
- refresh supporting styles including responsive spacing for the bank grid to match the updated homepage aesthetics
- rename the navigation label from “信用卡申请” to “信用卡” across pages and the page generator to keep the menu consistent

## Testing
- Visual inspection at http://localhost:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68dcacdccbfc8321a2271c57778e7d0e