### PR TITLE
Add global brokers directory and update navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -25,6 +25,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-details.html
+++ b/bank-details.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/abc.html
+++ b/bank-pages/abc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/baixin.html
+++ b/bank-pages/baixin.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/baoshang.html
+++ b/bank-pages/baoshang.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/bea.html
+++ b/bank-pages/bea.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/beibuwan.html
+++ b/bank-pages/beibuwan.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/beijing.html
+++ b/bank-pages/beijing.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/boc.html
+++ b/bank-pages/boc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/bohai.html
+++ b/bank-pages/bohai.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/ccb.html
+++ b/bank-pages/ccb.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/ceb.html
+++ b/bank-pages/ceb.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/cgb.html
+++ b/bank-pages/cgb.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/changan.html
+++ b/bank-pages/changan.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/changsha.html
+++ b/bank-pages/changsha.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/cib.html
+++ b/bank-pages/cib.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/citibank.html
+++ b/bank-pages/citibank.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/citic.html
+++ b/bank-pages/citic.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/cmb.html
+++ b/bank-pages/cmb.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/cmbc.html
+++ b/bank-pages/cmbc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/dalian.html
+++ b/bank-pages/dalian.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/dongguanrcc.html
+++ b/bank-pages/dongguanrcc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/fujianrcc.html
+++ b/bank-pages/fujianrcc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/gansu.html
+++ b/bank-pages/gansu.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/guangzhou.html
+++ b/bank-pages/guangzhou.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/guizhou.html
+++ b/bank-pages/guizhou.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/hangzhou.html
+++ b/bank-pages/hangzhou.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/harbin.html
+++ b/bank-pages/harbin.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/hengfeng.html
+++ b/bank-pages/hengfeng.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/hsbc.html
+++ b/bank-pages/hsbc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/huaxia.html
+++ b/bank-pages/huaxia.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/hubei.html
+++ b/bank-pages/hubei.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/icbc.html
+++ b/bank-pages/icbc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/jiangnanrcc.html
+++ b/bank-pages/jiangnanrcc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/jiangsurn.html
+++ b/bank-pages/jiangsurn.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/jiangxi.html
+++ b/bank-pages/jiangxi.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/jilin.html
+++ b/bank-pages/jilin.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/jinshang.html
+++ b/bank-pages/jinshang.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/jiujiang.html
+++ b/bank-pages/jiujiang.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/kunlun.html
+++ b/bank-pages/kunlun.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/mengshang.html
+++ b/bank-pages/mengshang.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/mintai.html
+++ b/bank-pages/mintai.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/nanjing.html
+++ b/bank-pages/nanjing.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/neimenggu.html
+++ b/bank-pages/neimenggu.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/ningbo.html
+++ b/bank-pages/ningbo.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/pingan.html
+++ b/bank-pages/pingan.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/psbc.html
+++ b/bank-pages/psbc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/qilu.html
+++ b/bank-pages/qilu.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/rizhao.html
+++ b/bank-pages/rizhao.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/shanghai.html
+++ b/bank-pages/shanghai.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/shengjing.html
+++ b/bank-pages/shengjing.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/shenzhenrcc.html
+++ b/bank-pages/shenzhenrcc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/sichuanrcu.html
+++ b/bank-pages/sichuanrcu.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/spdb.html
+++ b/bank-pages/spdb.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/standardchartered.html
+++ b/bank-pages/standardchartered.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/suzhourcc.html
+++ b/bank-pages/suzhourcc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/tailong.html
+++ b/bank-pages/tailong.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/tianfu.html
+++ b/bank-pages/tianfu.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/wuxircc.html
+++ b/bank-pages/wuxircc.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/yunnanrcu.html
+++ b/bank-pages/yunnanrcu.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/zheshang.html
+++ b/bank-pages/zheshang.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/bank-pages/zhongyuan.html
+++ b/bank-pages/zhongyuan.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="../global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="../credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/card-bin-lookup.html
+++ b/card-bin-lookup.html
@@ -27,6 +27,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/china-bank-codes.html
+++ b/china-bank-codes.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/cny-to-eur-exchange-rate.html
+++ b/cny-to-eur-exchange-rate.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/cny-to-usd-exchange-rate.html
+++ b/cny-to-usd-exchange-rate.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/credit-card-installment-calculator.html
+++ b/credit-card-installment-calculator.html
@@ -27,6 +27,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/credit-cards.html
+++ b/credit-cards.html
@@ -23,6 +23,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link active">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/exchange-rates.html
+++ b/exchange-rates.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/faq.html
+++ b/faq.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/favicon-demo.html
+++ b/favicon-demo.html
@@ -67,6 +67,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/global-banks.html
+++ b/global-banks.html
@@ -23,6 +23,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/global-brokers.html
+++ b/global-brokers.html
@@ -1,0 +1,901 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>全球券商大全 - 顶级证券公司联系方式</title>
+    <meta name="description" content="收录全球100家顶级券商，按地域汇总联系方式、监管牌照与核心业务，方便投资者快速比对与联系。">
+    <meta name="keywords" content="全球券商,证券公司,国际券商联系方式,顶级券商,海外券商">
+    <link rel="preload" href="style.css" as="style">
+    <link rel="stylesheet" href="style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <nav class="nav-menu">
+                <a href="index.html" class="nav-link">
+                    <i class="fas fa-home"></i>
+                    <span>国内银行</span>
+                </a>
+                <a href="global-banks.html" class="nav-link">
+                    <i class="fas fa-globe"></i>
+                    <span>全球银行</span>
+                </a>
+                <a href="global-brokers.html" class="nav-link active">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+                <a href="credit-cards.html" class="nav-link">
+                    <i class="fas fa-credit-card"></i>
+                    <span>信用卡</span>
+                </a>
+                <a href="exchange-rates.html" class="nav-link">
+                    <i class="fas fa-exchange-alt"></i>
+                    <span>实时汇率</span>
+                </a>
+                <a href="loan-interest-calculator.html" class="nav-link">
+                    <i class="fas fa-coins"></i>
+                    <span>贷款利率</span>
+                </a>
+                <a href="credit-card-installment-calculator.html" class="nav-link">
+                    <i class="fas fa-calculator"></i>
+                    <span>信用卡分期</span>
+                </a>
+                <a href="math-calculator.html" class="nav-link">
+                    <i class="fas fa-square-root-variable"></i>
+                    <span>多功能计算</span>
+                </a>
+                <a href="rmb-uppercase.html" class="nav-link">
+                    <i class="fas fa-yen-sign"></i>
+                    <span>人民币大写</span>
+                </a>
+                <a href="card-bin-lookup.html" class="nav-link">
+                    <i class="fas fa-magnifying-glass"></i>
+                    <span>BIN 查询</span>
+                </a>
+            </nav>
+        </div>
+    </header>
+    <main class="main">
+        <div class="container">
+            <nav class="breadcrumb" aria-label="面包屑导航">
+                <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <a href="/" itemprop="item"><span itemprop="name">首页</span></a>
+                        <meta itemprop="position" content="1" />
+                    </li>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">全球券商</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                </ol>
+            </nav>
+            <section class="hero">
+                <span class="hero-badge"><i class="fas fa-star"></i> 全球券商导航</span>
+                <h1 class="hero-title">全球100家顶级券商联系方式大全</h1>
+                <p class="hero-description">覆盖北美、欧洲、亚太、中东非洲与拉丁美洲五大区域的头部券商，列出监管信息、主营业务与客服渠道，助力跨市场配置与合规开户。</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="#region-overview"><i class="fas fa-location-dot"></i> 按地域快速定位</a>
+                    <a class="button secondary" href="global-banks.html"><i class="fas fa-globe"></i> 查看全球银行</a>
+                </div>
+            </section>
+            <section id="region-overview" class="service-section">
+                <h2 class="section-title"><i class="fas fa-compass"></i> 五大区域精选券商</h2>
+                <p class="section-description">各表格均支持横向滚动，建议结合所在国家监管要求与账户类型进行比对。</p>
+            </section>
+            <section class="reference-section">
+                <h3 class="section-title">
+                    <i class="fas fa-flag-usa"></i> 北美券商
+                </h3>
+                <p class="section-description">深入覆盖美国与加拿大领先网络券商，满足全球股票、期权、ETF与理财配置需求。</p>
+                <div class="table-wrapper">
+                    <table class="reference-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">券商</th>
+                                <th scope="col">总部所在地</th>
+                                <th scope="col">主要监管牌照</th>
+                                <th scope="col">联系方式</th>
+                                <th scope="col">核心业务</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><strong>盈透证券</strong><br><span class="text-muted">Interactive Brokers</span></td>
+                            <td>美国康涅狄格州格林尼治</td>
+                            <td>SEC / FINRA / FCA / MAS</td>
+                            <td><div>电话：<a href="tel:+18774422757">+1-877-442-2757</a></div><div><a href="https://www.interactivebrokers.com/en/general/contact.php" target="_blank" rel="noopener noreferrer">客服中心</a></div></td>
+                            <td>全球多资产交易、机构与高净值服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>嘉信理财</strong><br><span class="text-muted">Charles Schwab</span></td>
+                            <td>美国德克萨斯州韦斯特莱克</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18004354000">+1-800-435-4000</a></div><div><a href="https://www.schwab.com/contact-us" target="_blank" rel="noopener noreferrer">联系 Schwab</a></div></td>
+                            <td>零佣金股票、ETF、退休账户</td>
+                        </tr>
+                        <tr>
+                            <td><strong>富达投资</strong><br><span class="text-muted">Fidelity Investments</span></td>
+                            <td>美国马萨诸塞州波士顿</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18003433548">+1-800-343-3548</a></div><div><a href="https://www.fidelity.com/customer-service/contact-us" target="_blank" rel="noopener noreferrer">富达客服</a></div></td>
+                            <td>综合财富管理、指数基金、券商服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>德美利证券</strong><br><span class="text-muted">TD Ameritrade</span></td>
+                            <td>美国内布拉斯加州奥马哈</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18006693900">+1-800-669-3900</a></div><div><a href="https://www.tdameritrade.com/contact-us.html" target="_blank" rel="noopener noreferrer">联系 TD Ameritrade</a></div></td>
+                            <td>高频交易平台、期权与期货</td>
+                        </tr>
+                        <tr>
+                            <td><strong>亿创理财</strong><br><span class="text-muted">E*TRADE</span></td>
+                            <td>美国弗吉尼亚州阿灵顿</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18003872331">+1-800-387-2331</a></div><div><a href="https://us.etrade.com/contact" target="_blank" rel="noopener noreferrer">E*TRADE 支持</a></div></td>
+                            <td>自助交易、期权与退休计划</td>
+                        </tr>
+                        <tr>
+                            <td><strong>美林证券</strong><br><span class="text-muted">Merrill Edge</span></td>
+                            <td>美国新泽西州泽西城</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18776534732">+1-877-653-4732</a></div><div><a href="https://www.merrilledge.com/contact-us" target="_blank" rel="noopener noreferrer">Merrill Edge 联系</a></div></td>
+                            <td>美林智能投顾、ETF 与股票</td>
+                        </tr>
+                        <tr>
+                            <td><strong>先锋证券</strong><br><span class="text-muted">Vanguard Brokerage</span></td>
+                            <td>美国宾夕法尼亚州马尔文</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18776627447">+1-877-662-7447</a></div><div><a href="https://investor.vanguard.com/contact-us" target="_blank" rel="noopener noreferrer">先锋客服</a></div></td>
+                            <td>指数基金、ETF 与退休投资</td>
+                        </tr>
+                        <tr>
+                            <td><strong>罗宾侠</strong><br><span class="text-muted">Robinhood</span></td>
+                            <td>美国加利福尼亚州门洛帕克</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>APP 内申请回拨</div><div><a href="https://support.robinhood.com/hc/en-us" target="_blank" rel="noopener noreferrer">帮助中心</a></div></td>
+                            <td>移动端零佣金交易、加密资产</td>
+                        </tr>
+                        <tr>
+                            <td><strong>安联投资</strong><br><span class="text-muted">Ally Invest</span></td>
+                            <td>美国北卡罗来纳州夏洛特</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18558802559">+1-855-880-2559</a></div><div><a href="https://www.ally.com/contact/" target="_blank" rel="noopener noreferrer">Ally 联系</a></div></td>
+                            <td>美股、期权与现金管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>tastytrade</strong><br><span class="text-muted">tastytrade</span></td>
+                            <td>美国伊利诺伊州芝加哥</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18882471963">+1-888-247-1963</a></div><div><a href="https://tastytrade.com/contact-us" target="_blank" rel="noopener noreferrer">tastytrade 支持</a></div></td>
+                            <td>期权策略教育与在线交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>TradeStation</strong><br><span class="text-muted">TradeStation</span></td>
+                            <td>美国佛罗里达州普兰泰申</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18008089336">+1-800-808-9336</a></div><div><a href="https://www.tradestation.com/support/" target="_blank" rel="noopener noreferrer">TradeStation 支持</a></div></td>
+                            <td>专业级量化交易平台</td>
+                        </tr>
+                        <tr>
+                            <td><strong>微牛证券</strong><br><span class="text-muted">Webull</span></td>
+                            <td>美国纽约州纽约市</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18888280618">+1-888-828-0618</a></div><div><a href="https://www.webull.com/contact-us" target="_blank" rel="noopener noreferrer">Webull 联系</a></div></td>
+                            <td>美股、ETF、碎股交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>SoFi 投资</strong><br><span class="text-muted">SoFi Invest</span></td>
+                            <td>美国加利福尼亚州旧金山</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+18554567634">+1-855-456-7634</a></div><div><a href="https://www.sofi.com/contact-us/" target="_blank" rel="noopener noreferrer">SoFi 联系</a></div></td>
+                            <td>自动投顾、股票与加密资产</td>
+                        </tr>
+                        <tr>
+                            <td><strong>第一证券</strong><br><span class="text-muted">Firstrade</span></td>
+                            <td>美国纽约州法拉盛</td>
+                            <td>SEC / FINRA</td>
+                            <td><div>电话：<a href="tel:+17189616600">+1-718-961-6600</a></div><div><a href="https://www.firstrade.com/contact-us" target="_blank" rel="noopener noreferrer">Firstrade 客服</a></div></td>
+                            <td>中文支持美股、ETF 零佣金</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Questrade</strong><br><span class="text-muted">Questrade</span></td>
+                            <td>加拿大安大略省多伦多</td>
+                            <td>IIROC / CIPF</td>
+                            <td><div>电话：<a href="tel:+18887837866">+1-888-783-7866</a></div><div><a href="https://www.questrade.com/contact-us" target="_blank" rel="noopener noreferrer">Questrade 联系</a></div></td>
+                            <td>加拿大美股、ETF 低佣金交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Qtrade 直投</strong><br><span class="text-muted">Qtrade Direct Investing</span></td>
+                            <td>加拿大不列颠哥伦比亚省温哥华</td>
+                            <td>IIROC / CIPF</td>
+                            <td><div>电话：<a href="tel:+18777872330">+1-877-787-2330</a></div><div><a href="https://www.qtrade.ca/en/support/contact.html" target="_blank" rel="noopener noreferrer">Qtrade 支持</a></div></td>
+                            <td>退休账户、ETF 定投</td>
+                        </tr>
+                        <tr>
+                            <td><strong>加拿大国家银行直投</strong><br><span class="text-muted">National Bank Direct Brokerage</span></td>
+                            <td>加拿大魁北克省蒙特利尔</td>
+                            <td>IIROC / CIPF</td>
+                            <td><div>电话：<a href="tel:+18003633511">+1-800-363-3511</a></div><div><a href="https://www.nbc.ca/personal/contact-us.html" target="_blank" rel="noopener noreferrer">NBDB 联系</a></div></td>
+                            <td>北美股票、期权与研究</td>
+                        </tr>
+                        <tr>
+                            <td><strong>加拿大皇家银行直投</strong><br><span class="text-muted">RBC Direct Investing</span></td>
+                            <td>加拿大安大略省多伦多</td>
+                            <td>IIROC / CIPF</td>
+                            <td><div>电话：<a href="tel:+18007692560">+1-800-769-2560</a></div><div><a href="https://www.rbcroyalbank.com/investing/direct-investing/contact-us.html" target="_blank" rel="noopener noreferrer">RBC 联系</a></div></td>
+                            <td>股票、ETF、研究工具</td>
+                        </tr>
+                        <tr>
+                            <td><strong>蒙特利尔银行 InvestorLine</strong><br><span class="text-muted">BMO InvestorLine</span></td>
+                            <td>加拿大安大略省多伦多</td>
+                            <td>IIROC / CIPF</td>
+                            <td><div>电话：<a href="tel:+18887766886">+1-888-776-6886</a></div><div><a href="https://www.bmo.com/main/personal/investments/online-trading/contact-us/" target="_blank" rel="noopener noreferrer">BMO 联系</a></div></td>
+                            <td>自助交易、顾问服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>丰业银行 iTRADE</strong><br><span class="text-muted">Scotia iTRADE</span></td>
+                            <td>加拿大安大略省多伦多</td>
+                            <td>IIROC / CIPF</td>
+                            <td><div>电话：<a href="tel:+18888723388">+1-888-872-3388</a></div><div><a href="https://www.scotiaitrade.com/en/home/support/contact-us.html" target="_blank" rel="noopener noreferrer">Scotia iTRADE 支持</a></div></td>
+                            <td>股票、ETF、期权全渠道交易</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+            <section class="reference-section">
+                <h3 class="section-title">
+                    <i class="fas fa-earth-europe"></i> 欧洲券商
+                </h3>
+                <p class="section-description">覆盖伦敦、法兰克福、苏黎世等金融中心的综合券商与差价合约平台。</p>
+                <div class="table-wrapper">
+                    <table class="reference-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">券商</th>
+                                <th scope="col">总部所在地</th>
+                                <th scope="col">主要监管牌照</th>
+                                <th scope="col">联系方式</th>
+                                <th scope="col">核心业务</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><strong>盛宝银行</strong><br><span class="text-muted">Saxo Bank</span></td>
+                            <td>丹麦哥本哈根</td>
+                            <td>丹麦FSA / 英国FCA</td>
+                            <td><div>电话：<a href="tel:+4539774000">+45-3977-4000</a></div><div><a href="https://www.home.saxo/en/contact-us" target="_blank" rel="noopener noreferrer">Saxo 联系</a></div></td>
+                            <td>多资产交易、外汇与财富管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>IG 集团</strong><br><span class="text-muted">IG</span></td>
+                            <td>英国伦敦</td>
+                            <td>英国FCA / 德国BaFin</td>
+                            <td><div>电话：<a href="tel:+442076335300">+44-20-7633-5300</a></div><div><a href="https://www.ig.com/uk/help-and-support/contact-us" target="_blank" rel="noopener noreferrer">IG 支持</a></div></td>
+                            <td>差价合约、外汇与股票</td>
+                        </tr>
+                        <tr>
+                            <td><strong>CMC Markets</strong><br><span class="text-muted">CMC Markets</span></td>
+                            <td>英国伦敦</td>
+                            <td>英国FCA / 澳大利亚ASIC</td>
+                            <td><div>电话：<a href="tel:+442030038588">+44-20-3003-8588</a></div><div><a href="https://www.cmcmarkets.com/en/contact-us" target="_blank" rel="noopener noreferrer">CMC 联系</a></div></td>
+                            <td>差价合约与外汇交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>哈格里夫斯·兰斯当</strong><br><span class="text-muted">Hargreaves Lansdown</span></td>
+                            <td>英国布里斯托尔</td>
+                            <td>英国FCA</td>
+                            <td><div>电话：<a href="tel:+441179009000">+44-117-900-9000</a></div><div><a href="https://www.hl.co.uk/contact-us" target="_blank" rel="noopener noreferrer">HL 联系</a></div></td>
+                            <td>基金平台、股票 ISA、退休账户</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Plus500</strong><br><span class="text-muted">Plus500</span></td>
+                            <td>以色列海法 / 英国伦敦</td>
+                            <td>英国FCA / 澳大利亚ASIC</td>
+                            <td><div>24小时在线客服</div><div><a href="https://www.plus500.com/en/help/ContactUs" target="_blank" rel="noopener noreferrer">Plus500 支持</a></div></td>
+                            <td>差价合约、外汇与加密资产</td>
+                        </tr>
+                        <tr>
+                            <td><strong>DEGIRO</strong><br><span class="text-muted">DEGIRO</span></td>
+                            <td>荷兰阿姆斯特丹</td>
+                            <td>荷兰AFM / DNB</td>
+                            <td><div>电话：<a href="tel:+31202613072">+31-20-261-3072</a></div><div><a href="https://www.degiro.eu/helpdesk/contact" target="_blank" rel="noopener noreferrer">DEGIRO 帮助</a></div></td>
+                            <td>低成本欧洲证券交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>eToro</strong><br><span class="text-muted">eToro</span></td>
+                            <td>塞浦路斯利马索尔</td>
+                            <td>塞浦路斯CySEC / 英国FCA</td>
+                            <td><div>在线工单支持</div><div><a href="https://www.etoro.com/customer-service/" target="_blank" rel="noopener noreferrer">eToro 客服</a></div></td>
+                            <td>社交交易、加密与多资产</td>
+                        </tr>
+                        <tr>
+                            <td><strong>XTB</strong><br><span class="text-muted">XTB</span></td>
+                            <td>波兰华沙</td>
+                            <td>波兰KNF / 英国FCA</td>
+                            <td><div>电话：<a href="tel:+48222019500">+48-22-201-9500</a></div><div><a href="https://www.xtb.com/int/about-us/contact" target="_blank" rel="noopener noreferrer">XTB 联系</a></div></td>
+                            <td>外汇、差价合约、股票</td>
+                        </tr>
+                        <tr>
+                            <td><strong>瑞讯银行</strong><br><span class="text-muted">Swissquote</span></td>
+                            <td>瑞士古兰特</td>
+                            <td>瑞士FINMA</td>
+                            <td><div>电话：<a href="tel:+41448258888">+41-44-825-8888</a></div><div><a href="https://en.swissquote.com/company/contact" target="_blank" rel="noopener noreferrer">Swissquote 联系</a></div></td>
+                            <td>瑞士私人银行、证券与外汇</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Interactive Investor</strong><br><span class="text-muted">Interactive Investor</span></td>
+                            <td>英国曼彻斯特</td>
+                            <td>英国FCA</td>
+                            <td><div>电话：<a href="tel:+443442456183">+44-344-245-6183</a></div><div><a href="https://www.ii.co.uk/contact" target="_blank" rel="noopener noreferrer">ii 联系</a></div></td>
+                            <td>定额收费投资平台</td>
+                        </tr>
+                        <tr>
+                            <td><strong>AJ Bell Youinvest</strong><br><span class="text-muted">AJ Bell</span></td>
+                            <td>英国曼彻斯特</td>
+                            <td>英国FCA</td>
+                            <td><div>电话：<a href="tel:+443455432600">+44-345-543-2600</a></div><div><a href="https://www.ajbell.co.uk/contact" target="_blank" rel="noopener noreferrer">AJ Bell 联系</a></div></td>
+                            <td>ISA、SIPP、自主投资</td>
+                        </tr>
+                        <tr>
+                            <td><strong>FinecoBank</strong><br><span class="text-muted">FinecoBank</span></td>
+                            <td>意大利米兰</td>
+                            <td>意大利CONSOB / 英国FCA</td>
+                            <td><div>电话：<a href="tel:+448006406667">+44-800-640-6667</a></div><div><a href="https://www.finecobank.com/en/online/contact-us.html" target="_blank" rel="noopener noreferrer">Fineco 联系</a></div></td>
+                            <td>跨市场交易与财富管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>法国巴黎银行全球市场</strong><br><span class="text-muted">BNP Paribas Global Markets</span></td>
+                            <td>法国巴黎</td>
+                            <td>法国ACPR / AMF</td>
+                            <td><div>电话：<a href="tel:+33142981020">+33-1-4298-1020</a></div><div><a href="https://globalmarkets.bnpparibas.com/contact-us" target="_blank" rel="noopener noreferrer">BNP 联系</a></div></td>
+                            <td>机构经纪、衍生品与融资</td>
+                        </tr>
+                        <tr>
+                            <td><strong>兴业证券服务</strong><br><span class="text-muted">Société Générale Securities Services</span></td>
+                            <td>法国巴黎</td>
+                            <td>法国AMF</td>
+                            <td><div>电话：<a href="tel:+33142133407">+33-1-4213-3407</a></div><div><a href="https://www.securities-services.societegenerale.com/en/contact-us/" target="_blank" rel="noopener noreferrer">SGSS 联系</a></div></td>
+                            <td>托管、清算与主经纪商</td>
+                        </tr>
+                        <tr>
+                            <td><strong>德国商业银行</strong><br><span class="text-muted">Commerzbank</span></td>
+                            <td>德国法兰克福</td>
+                            <td>德国BaFin</td>
+                            <td><div>电话：<a href="tel:+496913620">+49-69-136-20</a></div><div><a href="https://www.commerzbank.com/en/hauptnavigation/konzern/kontakt/kontakt.html" target="_blank" rel="noopener noreferrer">Commerzbank 联系</a></div></td>
+                            <td>机构经纪、结构性产品</td>
+                        </tr>
+                        <tr>
+                            <td><strong>德国DKB Broker</strong><br><span class="text-muted">DKB Broker</span></td>
+                            <td>德国柏林</td>
+                            <td>德国BaFin</td>
+                            <td><div>电话：<a href="tel:+493012030000">+49-30-12030000</a></div><div><a href="https://www.dkb.de/kontakt/" target="_blank" rel="noopener noreferrer">DKB 联系</a></div></td>
+                            <td>ETF 定投、德股与美股交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Lynx Broker</strong><br><span class="text-muted">Lynx Broker</span></td>
+                            <td>荷兰阿姆斯特丹</td>
+                            <td>荷兰AFM</td>
+                            <td><div>电话：<a href="tel:+31202613072">+31-20-261-3072</a></div><div><a href="https://www.lynxbroker.com/contact/" target="_blank" rel="noopener noreferrer">Lynx 联系</a></div></td>
+                            <td>多市场经纪与专业交易者服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>flatexDEGIRO Bank</strong><br><span class="text-muted">flatexDEGIRO</span></td>
+                            <td>德国法兰克福</td>
+                            <td>德国BaFin</td>
+                            <td><div>电话：<a href="tel:+4992217035398">+49-9221-7035-398</a></div><div><a href="https://www.flatexdegiro.com/en/contact/" target="_blank" rel="noopener noreferrer">flatexDEGIRO 联系</a></div></td>
+                            <td>欧洲折扣券商与清算</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Admiral Markets</strong><br><span class="text-muted">Admirals</span></td>
+                            <td>爱沙尼亚塔林</td>
+                            <td>爱沙尼亚FSA / 英国FCA</td>
+                            <td><div>电话：<a href="tel:+442081577344">+44-20-8157-7344</a></div><div><a href="https://admiralmarkets.com/contact-us" target="_blank" rel="noopener noreferrer">Admirals 联系</a></div></td>
+                            <td>外汇与差价合约</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Trading 212</strong><br><span class="text-muted">Trading 212</span></td>
+                            <td>英国伦敦</td>
+                            <td>英国FCA / 保加利亚FSC</td>
+                            <td><div>电话：<a href="tel:+442037699897">+44-20-3769-9897</a></div><div><a href="https://helpcentre.trading212.com/hc/en-us" target="_blank" rel="noopener noreferrer">Trading 212 支持</a></div></td>
+                            <td>零佣金股票与差价合约</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+            <section class="reference-section">
+                <h3 class="section-title">
+                    <i class="fas fa-earth-asia"></i> 亚太券商
+                </h3>
+                <p class="section-description">囊括日本、香港、新加坡与澳洲的主流持牌券商。</p>
+                <div class="table-wrapper">
+                    <table class="reference-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">券商</th>
+                                <th scope="col">总部所在地</th>
+                                <th scope="col">主要监管牌照</th>
+                                <th scope="col">联系方式</th>
+                                <th scope="col">核心业务</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><strong>野村证券</strong><br><span class="text-muted">Nomura Securities</span></td>
+                            <td>日本东京</td>
+                            <td>日本FSA / JSDA</td>
+                            <td><div>电话：<a href="tel:+81367482111">+81-3-6748-2111</a></div><div><a href="https://www.nomuraholdings.com/contact/" target="_blank" rel="noopener noreferrer">野村联系</a></div></td>
+                            <td>机构经纪、投行业务、零售服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>大和证券</strong><br><span class="text-muted">Daiwa Securities</span></td>
+                            <td>日本东京</td>
+                            <td>日本FSA / JSDA</td>
+                            <td><div>电话：<a href="tel:+81355551111">+81-3-5555-1111</a></div><div><a href="https://www.daiwa.jp/contact/" target="_blank" rel="noopener noreferrer">大和客服</a></div></td>
+                            <td>零售证券、机构经纪、资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>SBI 证券</strong><br><span class="text-muted">SBI Securities</span></td>
+                            <td>日本东京</td>
+                            <td>日本FSA</td>
+                            <td><div>电话：<a href="tel:+81355627210">+81-3-5562-7210</a></div><div><a href="https://faq.sbisec.co.jp" target="_blank" rel="noopener noreferrer">SBI 联系</a></div></td>
+                            <td>网络股票、基金与外汇</td>
+                        </tr>
+                        <tr>
+                            <td><strong>乐天证券</strong><br><span class="text-muted">Rakuten Securities</span></td>
+                            <td>日本东京</td>
+                            <td>日本FSA</td>
+                            <td><div>电话：<a href="tel:+81343321150">+81-3-4332-1150</a></div><div><a href="https://www.rakuten-sec.co.jp/web/info/support/" target="_blank" rel="noopener noreferrer">乐天客服</a></div></td>
+                            <td>互联网股票、ETF、外汇</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Monex 证券</strong><br><span class="text-muted">Monex</span></td>
+                            <td>日本东京</td>
+                            <td>日本FSA</td>
+                            <td><div>电话：<a href="tel:+81343214550">+81-3-4321-4550</a></div><div><a href="https://www.monex.co.jp/AboutUs/contact/index.htm" target="_blank" rel="noopener noreferrer">Monex 联系</a></div></td>
+                            <td>美股、日股、加密资产</td>
+                        </tr>
+                        <tr>
+                            <td><strong>三井住友日兴证券</strong><br><span class="text-muted">SMBC Nikko Securities</span></td>
+                            <td>日本东京</td>
+                            <td>日本FSA</td>
+                            <td><div>电话：<a href="tel:+81367338500">+81-3-6733-8500</a></div><div><a href="https://www.smbcnikko.co.jp/service/contact/" target="_blank" rel="noopener noreferrer">SMBC Nikko 联系</a></div></td>
+                            <td>财富管理、投顾、股票承销</td>
+                        </tr>
+                        <tr>
+                            <td><strong>辉立证券</strong><br><span class="text-muted">Phillip Securities</span></td>
+                            <td>新加坡</td>
+                            <td>新加坡MAS</td>
+                            <td><div>电话：<a href="tel:+6565336001">+65-6533-6001</a></div><div><a href="https://www.poems.com.sg/contact-us/" target="_blank" rel="noopener noreferrer">辉立联系</a></div></td>
+                            <td>亚太股票、结构性产品</td>
+                        </tr>
+                        <tr>
+                            <td><strong>星展唯高达</strong><br><span class="text-muted">DBS Vickers</span></td>
+                            <td>新加坡</td>
+                            <td>新加坡MAS</td>
+                            <td><div>电话：<a href="tel:+6563272288">+65-6327-2288</a></div><div><a href="https://www.dbs.com.sg/personal/support/dbs-vickers-customer-service" target="_blank" rel="noopener noreferrer">DBS Vickers 联系</a></div></td>
+                            <td>新加坡及全球股票交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>华侨银行证券</strong><br><span class="text-muted">OCBC Securities</span></td>
+                            <td>新加坡</td>
+                            <td>新加坡MAS</td>
+                            <td><div>电话：<a href="tel:+6565352882">+65-6535-2882</a></div><div><a href="https://www.iocbc.com/contact-us.page" target="_blank" rel="noopener noreferrer">OCBC 联系</a></div></td>
+                            <td>亚太股票、期权与融资</td>
+                        </tr>
+                        <tr>
+                            <td><strong>大华继显</strong><br><span class="text-muted">UOB Kay Hian</span></td>
+                            <td>新加坡</td>
+                            <td>新加坡MAS</td>
+                            <td><div>电话：<a href="tel:+6565369338">+65-6536-9338</a></div><div><a href="https://www.uobkayhian.com/clients_resource/contact_us" target="_blank" rel="noopener noreferrer">UOB Kay Hian 联系</a></div></td>
+                            <td>区域股票经纪、IPO 承销</td>
+                        </tr>
+                        <tr>
+                            <td><strong>马来亚银行证券</strong><br><span class="text-muted">Maybank Securities</span></td>
+                            <td>新加坡 / 马来西亚</td>
+                            <td>新加坡MAS / 马来西亚SC</td>
+                            <td><div>电话：<a href="tel:+6565336288">+65-6533-6288</a></div><div><a href="https://www.maybanktrade.com.sg/contact-us" target="_blank" rel="noopener noreferrer">Maybank 联系</a></div></td>
+                            <td>区域股票与ETF</td>
+                        </tr>
+                        <tr>
+                            <td><strong>联昌证券</strong><br><span class="text-muted">CIMB Investment Bank</span></td>
+                            <td>马来西亚吉隆坡</td>
+                            <td>马来西亚SC</td>
+                            <td><div>电话：<a href="tel:+60322618888">+60-3-2261-8888</a></div><div><a href="https://www.cimb.com/en/contact-us.html" target="_blank" rel="noopener noreferrer">CIMB 联系</a></div></td>
+                            <td>投行、经纪与资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>汇丰证券</strong><br><span class="text-muted">HSBC Broking</span></td>
+                            <td>中国香港</td>
+                            <td>香港证监会</td>
+                            <td><div>电话：<a href="tel:+85229966730">+852-2996-6730</a></div><div><a href="https://www.hsbc.com.hk/investments/securities-brokerage/contact/" target="_blank" rel="noopener noreferrer">汇丰联系</a></div></td>
+                            <td>港股、美股、衍生品</td>
+                        </tr>
+                        <tr>
+                            <td><strong>海通国际</strong><br><span class="text-muted">Haitong International</span></td>
+                            <td>中国香港</td>
+                            <td>香港证监会</td>
+                            <td><div>电话：<a href="tel:+85222132500">+852-2213-2500</a></div><div><a href="https://www.htisec.com/en/contact-us" target="_blank" rel="noopener noreferrer">海通联系</a></div></td>
+                            <td>跨境证券、固定收益、资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>中信证券</strong><br><span class="text-muted">CITIC Securities</span></td>
+                            <td>中国深圳</td>
+                            <td>中国证监会</td>
+                            <td><div>电话：<a href="tel:+8695548">+86-95548</a></div><div><a href="https://www.cs.ecitic.com/newsite/service/contactus/" target="_blank" rel="noopener noreferrer">中信客服</a></div></td>
+                            <td>全牌照投资银行与经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>广发证券</strong><br><span class="text-muted">GF Securities</span></td>
+                            <td>中国广州</td>
+                            <td>中国证监会</td>
+                            <td><div>电话：<a href="tel:+8695385">+86-95385</a></div><div><a href="https://www.gf.com.cn/contactus/index.shtml" target="_blank" rel="noopener noreferrer">广发联系</a></div></td>
+                            <td>财富管理、机构经纪、投行</td>
+                        </tr>
+                        <tr>
+                            <td><strong>中国国际金融股份</strong><br><span class="text-muted">China International Capital Corporation</span></td>
+                            <td>中国北京</td>
+                            <td>中国证监会</td>
+                            <td><div>电话：<a href="tel:+864009101166">+86-400-910-1166</a></div><div><a href="https://www.cicc.com/contact_us.shtml" target="_blank" rel="noopener noreferrer">中金联系</a></div></td>
+                            <td>投资银行、资产管理、研究</td>
+                        </tr>
+                        <tr>
+                            <td><strong>麦格理集团</strong><br><span class="text-muted">Macquarie Group</span></td>
+                            <td>澳大利亚悉尼</td>
+                            <td>澳大利亚ASIC</td>
+                            <td><div>电话：<a href="tel:+61282323333">+61-2-8232-3333</a></div><div><a href="https://www.macquarie.com/au/en/contact.html" target="_blank" rel="noopener noreferrer">麦格理联系</a></div></td>
+                            <td>投行、资产管理与经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>澳盛证券 CommSec</strong><br><span class="text-muted">CommSec</span></td>
+                            <td>澳大利亚悉尼</td>
+                            <td>澳大利亚ASIC</td>
+                            <td><div>电话：<a href="tel:+61131519">+61-13-15-19</a></div><div><a href="https://www.commsec.com.au/support.html" target="_blank" rel="noopener noreferrer">CommSec 支持</a></div></td>
+                            <td>澳股、美股在线交易</td>
+                        </tr>
+                        <tr>
+                            <td><strong>澳洲国民银行 nabtrade</strong><br><span class="text-muted">nabtrade</span></td>
+                            <td>澳大利亚墨尔本</td>
+                            <td>澳大利亚ASIC</td>
+                            <td><div>电话：<a href="tel:+61131380">+61-13-13-80</a></div><div><a href="https://www.nabtrade.com.au/contact-us" target="_blank" rel="noopener noreferrer">nabtrade 联系</a></div></td>
+                            <td>股票、ETF、固定收益投资</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+            <section class="reference-section">
+                <h3 class="section-title">
+                    <i class="fas fa-earth-africa"></i> 中东与非洲券商
+                </h3>
+                <p class="section-description">覆盖中东海湾合作委员会及非洲主要资本市场的头部券商。</p>
+                <div class="table-wrapper">
+                    <table class="reference-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">券商</th>
+                                <th scope="col">总部所在地</th>
+                                <th scope="col">主要监管牌照</th>
+                                <th scope="col">联系方式</th>
+                                <th scope="col">核心业务</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><strong>阿联酋国民银行证券</strong><br><span class="text-muted">Emirates NBD Securities</span></td>
+                            <td>阿联酋迪拜</td>
+                            <td>阿联酋SCA</td>
+                            <td><div>电话：<a href="tel:+97142366700">+971-4-236-6700</a></div><div><a href="https://www.emiratesnbd.com/en/corporate-and-institutional/securities/contact-us" target="_blank" rel="noopener noreferrer">ENBD 联系</a></div></td>
+                            <td>海湾股票、债券交易与托管</td>
+                        </tr>
+                        <tr>
+                            <td><strong>阿布扎比商业银行证券</strong><br><span class="text-muted">ADCB Securities</span></td>
+                            <td>阿联酋阿布扎比</td>
+                            <td>阿联酋SCA</td>
+                            <td><div>电话：<a href="tel:+97126104141">+971-2-610-4141</a></div><div><a href="https://www.adcbsecurities.com/contact-us.aspx" target="_blank" rel="noopener noreferrer">ADCB 联系</a></div></td>
+                            <td>阿联酋股票经纪、托管</td>
+                        </tr>
+                        <tr>
+                            <td><strong>阿布扎比第一银行证券</strong><br><span class="text-muted">FAB Securities</span></td>
+                            <td>阿联酋阿布扎比</td>
+                            <td>阿联酋SCA</td>
+                            <td><div>电话：<a href="tel:+97126161600">+971-2-616-1600</a></div><div><a href="https://www.bankfab.com/en-ae/about-fab/contact-us" target="_blank" rel="noopener noreferrer">FAB 联系</a></div></td>
+                            <td>机构与零售股票经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>阿布扎比证券公司</strong><br><span class="text-muted">ADSS</span></td>
+                            <td>阿联酋阿布扎比</td>
+                            <td>阿联酋SCA / 英国FCA</td>
+                            <td><div>电话：<a href="tel:+97126572300">+971-2-657-2300</a></div><div><a href="https://www.adss.com/en/contact/" target="_blank" rel="noopener noreferrer">ADSS 联系</a></div></td>
+                            <td>外汇、差价合约与机构流动性</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Al Ramz Capital</strong><br><span class="text-muted">Al Ramz</span></td>
+                            <td>阿联酋阿布扎比</td>
+                            <td>阿联酋SCA</td>
+                            <td><div>电话：<a href="tel:+97126118888">+971-2-611-8888</a></div><div><a href="https://www.alramz.ae/contact-us" target="_blank" rel="noopener noreferrer">Al Ramz 联系</a></div></td>
+                            <td>经纪、自营与资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>马什里克证券</strong><br><span class="text-muted">Mashreq Securities</span></td>
+                            <td>阿联酋迪拜</td>
+                            <td>阿联酋SCA</td>
+                            <td><div>电话：<a href="tel:+97142307800">+971-4-230-7800</a></div><div><a href="https://www.mashreq.com/en/uae/business/brokerage/contact-us" target="_blank" rel="noopener noreferrer">Mashreq 联系</a></div></td>
+                            <td>阿联酋及区域股票经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>卡塔尔国家银行金融服务</strong><br><span class="text-muted">QNB Financial Services</span></td>
+                            <td>卡塔尔多哈</td>
+                            <td>卡塔尔QFMA</td>
+                            <td><div>电话：<a href="tel:+97444766666">+974-4476-6666</a></div><div><a href="https://www.qnbfs.com/contact-us" target="_blank" rel="noopener noreferrer">QNB 联系</a></div></td>
+                            <td>卡塔尔证券市场经纪与研究</td>
+                        </tr>
+                        <tr>
+                            <td><strong>卡塔尔投资银行</strong><br><span class="text-muted">QInvest</span></td>
+                            <td>卡塔尔多哈</td>
+                            <td>卡塔尔QFCRA</td>
+                            <td><div>电话：<a href="tel:+97444961700">+974-4496-1700</a></div><div><a href="https://www.qinvest.com/en/contact-us" target="_blank" rel="noopener noreferrer">QInvest 联系</a></div></td>
+                            <td>投行、资产管理与经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>沙特国家银行资本</strong><br><span class="text-muted">SNB Capital</span></td>
+                            <td>沙特利雅得</td>
+                            <td>沙特CMA</td>
+                            <td><div>电话：<a href="tel:+966920002324">+966-92000-2324</a></div><div><a href="https://www.snbcapital.com/en/Pages/ContactUs.aspx" target="_blank" rel="noopener noreferrer">SNB 联系</a></div></td>
+                            <td>经纪、资产管理与投行</td>
+                        </tr>
+                        <tr>
+                            <td><strong>沙特拉吉银行资本</strong><br><span class="text-muted">Al Rajhi Capital</span></td>
+                            <td>沙特利雅得</td>
+                            <td>沙特CMA</td>
+                            <td><div>电话：<a href="tel:+966920005859">+966-92000-5859</a></div><div><a href="https://www.alrajhi-capital.com/en-us/contact-us/" target="_blank" rel="noopener noreferrer">Al Rajhi 联系</a></div></td>
+                            <td>零售与机构经纪、资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>沙特法兴资本</strong><br><span class="text-muted">Saudi Fransi Capital</span></td>
+                            <td>沙特利雅得</td>
+                            <td>沙特CMA</td>
+                            <td><div>电话：<a href="tel:+966920005500">+966-92000-5500</a></div><div><a href="https://www.fransicapital.com.sa/english/contact-us" target="_blank" rel="noopener noreferrer">Fransi 联系</a></div></td>
+                            <td>资本市场、资产管理、经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>EFG Hermes</strong><br><span class="text-muted">EFG Hermes</span></td>
+                            <td>阿联酋迪拜 / 埃及开罗</td>
+                            <td>埃及FRA / 阿联酋DFSA</td>
+                            <td><div>电话：<a href="tel:+97143637411">+971-4-363-7411</a></div><div><a href="https://www.efghermes.com/en/ContactUs" target="_blank" rel="noopener noreferrer">EFG Hermes 联系</a></div></td>
+                            <td>中东与非洲投资银行与经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Beltone Financial</strong><br><span class="text-muted">Beltone Financial</span></td>
+                            <td>埃及开罗</td>
+                            <td>埃及FRA</td>
+                            <td><div>电话：<a href="tel:+20233382000">+20-2-3338-2000</a></div><div><a href="https://www.beltonefinancial.com/contact-us/" target="_blank" rel="noopener noreferrer">Beltone 联系</a></div></td>
+                            <td>埃及证券经纪、资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>FBNQuest Securities</strong><br><span class="text-muted">FBNQuest Securities</span></td>
+                            <td>尼日利亚拉各斯</td>
+                            <td>尼日利亚SEC</td>
+                            <td><div>电话：<a href="tel:+23412808864">+234-1-280-8864</a></div><div><a href="https://fbnquest.com/contact/" target="_blank" rel="noopener noreferrer">FBNQuest 联系</a></div></td>
+                            <td>西非经纪、投行与研究</td>
+                        </tr>
+                        <tr>
+                            <td><strong>标准银行在线交易</strong><br><span class="text-muted">Standard Bank Online Trading</span></td>
+                            <td>南非约翰内斯堡</td>
+                            <td>南非FSCA</td>
+                            <td><div>电话：<a href="tel:+27114157000">+27-11-415-7000</a></div><div><a href="https://securities.standardbank.co.za/ost/en/contact-us" target="_blank" rel="noopener noreferrer">Standard Bank 联系</a></div></td>
+                            <td>南非股票、ETF 与衍生品</td>
+                        </tr>
+                        <tr>
+                            <td><strong>南非Nedbank 私人财富证券</strong><br><span class="text-muted">Nedbank Private Wealth Stockbrokers</span></td>
+                            <td>南非开普敦</td>
+                            <td>南非FSCA</td>
+                            <td><div>电话：<a href="tel:+27214166000">+27-21-416-6000</a></div><div><a href="https://www.nedbankprivatewealth.co.za/contact-us" target="_blank" rel="noopener noreferrer">Nedbank 联系</a></div></td>
+                            <td>高净值交易与财富规划</td>
+                        </tr>
+                        <tr>
+                            <td><strong>PSG 财富管理</strong><br><span class="text-muted">PSG Wealth</span></td>
+                            <td>南非斯泰伦博斯</td>
+                            <td>南非FSCA</td>
+                            <td><div>电话：<a href="tel:+27218879600">+27-21-887-9600</a></div><div><a href="https://www.psg.co.za/psg-wealth/contact-us" target="_blank" rel="noopener noreferrer">PSG 联系</a></div></td>
+                            <td>南非证券、投顾与资产配置</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Absa 股票经纪</strong><br><span class="text-muted">Absa Stockbrokers</span></td>
+                            <td>南非约翰内斯堡</td>
+                            <td>南非FSCA</td>
+                            <td><div>电话：<a href="tel:+27860050937">+27-860-050-937</a></div><div><a href="https://www.absastockbrokers.co.za/online-share-trading/about/contact-us" target="_blank" rel="noopener noreferrer">Absa 联系</a></div></td>
+                            <td>本地与全球股票、ETF</td>
+                        </tr>
+                        <tr>
+                            <td><strong>保障信托银行证券</strong><br><span class="text-muted">GTBank Securities</span></td>
+                            <td>尼日利亚拉各斯</td>
+                            <td>尼日利亚SEC</td>
+                            <td><div>电话：<a href="tel:+23414480000">+234-1-448-0000</a></div><div><a href="https://www.gtbank.com/about/investor-relations/contact-us" target="_blank" rel="noopener noreferrer">GTBank 联系</a></div></td>
+                            <td>尼日利亚股票经纪与投资服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Sanlam 私人财富</strong><br><span class="text-muted">Sanlam Private Wealth</span></td>
+                            <td>南非开普敦</td>
+                            <td>南非FSCA</td>
+                            <td><div>电话：<a href="tel:+27219502777">+27-21-950-2777</a></div><div><a href="https://sanlamprivatewealth.sanlam.com/contact-us/" target="_blank" rel="noopener noreferrer">Sanlam 联系</a></div></td>
+                            <td>高净值财富管理与经纪</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+            <section class="reference-section">
+                <h3 class="section-title">
+                    <i class="fas fa-earth-americas"></i> 拉丁美洲券商
+                </h3>
+                <p class="section-description">精选巴西、墨西哥、安第斯区域的数字券商与传统券商。</p>
+                <div class="table-wrapper">
+                    <table class="reference-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">券商</th>
+                                <th scope="col">总部所在地</th>
+                                <th scope="col">主要监管牌照</th>
+                                <th scope="col">联系方式</th>
+                                <th scope="col">核心业务</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><strong>XP Investimentos</strong><br><span class="text-muted">XP Investimentos</span></td>
+                            <td>巴西圣保罗</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551140033710">+55-11-4003-3710</a></div><div><a href="https://conteudos.xpi.com.br/atendimento/" target="_blank" rel="noopener noreferrer">XP 联系</a></div></td>
+                            <td>全市场交易、财富管理、投顾</td>
+                        </tr>
+                        <tr>
+                            <td><strong>BTG Pactual digital</strong><br><span class="text-muted">BTG Pactual digital</span></td>
+                            <td>巴西圣保罗</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551133836680">+55-11-3383-6680</a></div><div><a href="https://www.btgpactualdigital.com/contato" target="_blank" rel="noopener noreferrer">BTG 联系</a></div></td>
+                            <td>在线投资、私募与财富管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>伊塔乌券商</strong><br><span class="text-muted">Itaú Corretora</span></td>
+                            <td>巴西圣保罗</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551130034770">+55-11-3003-4770</a></div><div><a href="https://www.itau.com.br/investimentos/atendimento/" target="_blank" rel="noopener noreferrer">Itaú 联系</a></div></td>
+                            <td>股票、期权、固定收益</td>
+                        </tr>
+                        <tr>
+                            <td><strong>布拉德斯科券商</strong><br><span class="text-muted">Bradesco Corretora</span></td>
+                            <td>巴西奥萨斯库</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551130034557">+55-11-3003-4557</a></div><div><a href="https://www.bradescocorretora.com.br/#!/atendimento" target="_blank" rel="noopener noreferrer">Bradesco 联系</a></div></td>
+                            <td>多市场基金、股票、固定收益</td>
+                        </tr>
+                        <tr>
+                            <td><strong>巴西银行投资</strong><br><span class="text-muted">BB Investimentos</span></td>
+                            <td>巴西巴西利亚</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551140040001">+55-11-4004-0001</a></div><div><a href="https://www.bb.com.br/site/pra-voce/atendimento/central-de-atendimento/" target="_blank" rel="noopener noreferrer">BB 联系</a></div></td>
+                            <td>投资银行、经纪与研究</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Modalmais</strong><br><span class="text-muted">Modal Mais</span></td>
+                            <td>巴西里约热内卢</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+552130306330">+55-21-3030-6330</a></div><div><a href="https://www.modalmais.com.br/atendimento" target="_blank" rel="noopener noreferrer">Modal 联系</a></div></td>
+                            <td>数字券商、固定收益与基金</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Rico Investimentos</strong><br><span class="text-muted">Rico Investimentos</span></td>
+                            <td>巴西圣保罗</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551130035465">+55-11-3003-5465</a></div><div><a href="https://ajuda.rico.com.vc/s/" target="_blank" rel="noopener noreferrer">Rico 联系</a></div></td>
+                            <td>在线投资教育与券商服务</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Clear Corretora</strong><br><span class="text-muted">Clear Corretora</span></td>
+                            <td>巴西圣保罗</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551138414515">+55-11-3841-4515</a></div><div><a href="https://ajuda.clear.com.br/s/" target="_blank" rel="noopener noreferrer">Clear 联系</a></div></td>
+                            <td>日内交易、股票与期权</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Guide Investimentos</strong><br><span class="text-muted">Guide Investimentos</span></td>
+                            <td>巴西圣保罗</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+551135127100">+55-11-3512-7100</a></div><div><a href="https://www.guide.com.br/atendimento" target="_blank" rel="noopener noreferrer">Guide 联系</a></div></td>
+                            <td>财富顾问、资产配置</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Órama Investimentos</strong><br><span class="text-muted">Órama Investimentos</span></td>
+                            <td>巴西里约热内卢</td>
+                            <td>巴西CVM / B3</td>
+                            <td><div>电话：<a href="tel:+552131390030">+55-21-3139-0030</a></div><div><a href="https://www.orama.com.br/atendimento" target="_blank" rel="noopener noreferrer">Órama 联系</a></div></td>
+                            <td>基金超市、数字财富管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>桑坦德墨西哥券商</strong><br><span class="text-muted">Santander Casa de Bolsa México</span></td>
+                            <td>墨西哥墨西哥城</td>
+                            <td>墨西哥CNBV</td>
+                            <td><div>电话：<a href="tel:+525551694300">+52-55-5169-4300</a></div><div><a href="https://www.santander.com.mx/personas/contacto.html" target="_blank" rel="noopener noreferrer">Santander 联系</a></div></td>
+                            <td>墨西哥股票、基金与咨询</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Actinver 券商</strong><br><span class="text-muted">Actinver Casa de Bolsa</span></td>
+                            <td>墨西哥墨西哥城</td>
+                            <td>墨西哥CNBV</td>
+                            <td><div>电话：<a href="tel:+525511036600">+52-55-1103-6600</a></div><div><a href="https://www.actinver.com/contacto" target="_blank" rel="noopener noreferrer">Actinver 联系</a></div></td>
+                            <td>经纪、自营与财富管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>GBM 墨西哥证券集团</strong><br><span class="text-muted">GBM Grupo Bursátil Mexicano</span></td>
+                            <td>墨西哥墨西哥城</td>
+                            <td>墨西哥CNBV</td>
+                            <td><div>电话：<a href="tel:+525554805800">+52-55-5480-5800</a></div><div><a href="https://www.gbm.com/contacto/" target="_blank" rel="noopener noreferrer">GBM 联系</a></div></td>
+                            <td>数字券商、资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Banorte 券商</strong><br><span class="text-muted">Banorte Casa de Bolsa</span></td>
+                            <td>墨西哥蒙特雷</td>
+                            <td>墨西哥CNBV</td>
+                            <td><div>电话：<a href="tel:+528183189933">+52-81-8318-9933</a></div><div><a href="https://www.banorte.com/wps/portal/banorte/Home/contactanos" target="_blank" rel="noopener noreferrer">Banorte 联系</a></div></td>
+                            <td>经纪、衍生品与财富管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Scotia Inverlat</strong><br><span class="text-muted">Scotia Inverlat Casa de Bolsa</span></td>
+                            <td>墨西哥墨西哥城</td>
+                            <td>墨西哥CNBV</td>
+                            <td><div>电话：<a href="tel:+525557281900">+52-55-5728-1900</a></div><div><a href="https://www.scotiabank.com.mx/es/personas/contactanos.html" target="_blank" rel="noopener noreferrer">Scotia 联系</a></div></td>
+                            <td>经纪、投资组合咨询</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Credicorp Capital</strong><br><span class="text-muted">Credicorp Capital</span></td>
+                            <td>哥伦比亚波哥大</td>
+                            <td>哥伦比亚SFC / 智利CMF</td>
+                            <td><div>电话：<a href="tel:+5716587000">+57-1-658-7000</a></div><div><a href="https://www.credicorpcapital.com/en/contact/" target="_blank" rel="noopener noreferrer">Credicorp 联系</a></div></td>
+                            <td>安第斯地区经纪、资产管理</td>
+                        </tr>
+                        <tr>
+                            <td><strong>智利银行投资</strong><br><span class="text-muted">Banchile Inversiones</span></td>
+                            <td>智利圣地亚哥</td>
+                            <td>智利CMF</td>
+                            <td><div>电话：<a href="tel:+56226567000">+56-2-2656-7000</a></div><div><a href="https://www.banchileinversiones.cl/personas/contacto" target="_blank" rel="noopener noreferrer">Banchile 联系</a></div></td>
+                            <td>智利股票、基金与顾问</td>
+                        </tr>
+                        <tr>
+                            <td><strong>LarrainVial</strong><br><span class="text-muted">LarrainVial</span></td>
+                            <td>智利圣地亚哥</td>
+                            <td>智利CMF</td>
+                            <td><div>电话：<a href="tel:+56226178000">+56-2-2617-8000</a></div><div><a href="https://www.larrainvial.com/contacto/" target="_blank" rel="noopener noreferrer">LarrainVial 联系</a></div></td>
+                            <td>区域经纪、资产管理、投顾</td>
+                        </tr>
+                        <tr>
+                            <td><strong>花旗墨西哥券商</strong><br><span class="text-muted">Citibanamex Casa de Bolsa</span></td>
+                            <td>墨西哥墨西哥城</td>
+                            <td>墨西哥CNBV</td>
+                            <td><div>电话：<a href="tel:+525512262639">+52-55-1226-2639</a></div><div><a href="https://www.banamex.com/es/contacto.html" target="_blank" rel="noopener noreferrer">Citibanamex 联系</a></div></td>
+                            <td>墨西哥资本市场经纪</td>
+                        </tr>
+                        <tr>
+                            <td><strong>InvertirOnline</strong><br><span class="text-muted">InvertirOnline</span></td>
+                            <td>阿根廷布宜诺斯艾利斯</td>
+                            <td>阿根廷CNV</td>
+                            <td><div>电话：<a href="tel:+541139807258">+54-11-3980-7258</a></div><div><a href="https://www.invertironline.com/contacto" target="_blank" rel="noopener noreferrer">InvertirOnline 联系</a></div></td>
+                            <td>阿根廷及美国股票、债券</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+    </main>
+    <footer class="footer">
+        <div class="container">
+            <p>以上信息来源于各券商官网公开资料，建议在开户前再次核实最新条款与费用。</p>
+            <p>&copy; 2024 yinhangka.online</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/global-common-bank-codes.html
+++ b/global-common-bank-codes.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/loan-interest-calculator.html
+++ b/loan-interest-calculator.html
@@ -27,6 +27,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/math-calculator.html
+++ b/math-calculator.html
@@ -27,6 +27,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/picturesize/index.html
+++ b/picturesize/index.html
@@ -22,6 +22,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="/global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="/credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/rmb-uppercase.html
+++ b/rmb-uppercase.html
@@ -27,6 +27,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/search/index.html
+++ b/search/index.html
@@ -22,6 +22,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="/global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="/credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -297,6 +297,10 @@
         <lastmod>2025-10-02</lastmod>
     </url>
     <url>
+        <loc>https://yinhangka.online/global-brokers.html</loc>
+        <lastmod>2025-10-02</lastmod>
+    </url>
+    <url>
         <loc>https://yinhangka.online/loan-interest-calculator.html</loc>
         <lastmod>2025-10-02</lastmod>
     </url>

--- a/terms.html
+++ b/terms.html
@@ -21,6 +21,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="/global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="/credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>

--- a/us-bank-codes.html
+++ b/us-bank-codes.html
@@ -26,6 +26,11 @@
                     <i class="fas fa-globe"></i>
                     <span>全球银行</span>
                 </a>
+                <a href="global-brokers.html" class="nav-link">
+                    <i class="fas fa-briefcase"></i>
+                    <span>全球券商</span>
+                </a>
+
                 <a href="credit-cards.html" class="nav-link">
                     <i class="fas fa-credit-card"></i>
                     <span>信用卡</span>


### PR DESCRIPTION
## Summary
- add a global brokers resource page that lists 100 leading firms by region with contact channels and regulatory notes
- add a global brokers navigation link across the site and register the page in the sitemap for discovery

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3d995f3248321bfbf844667a20486